### PR TITLE
Make `PartialEq<PublicKey>` conform to RFC7748 and `PrivateKey` into wrapper over `Scalar`

### DIFF
--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -510,12 +510,10 @@ pub struct PrivateKey {
 
 impl PartialEq<&[u8]> for PrivateKey {
     fn eq(&self, other: &&[u8]) -> bool {
-        if other.len() != PRIVATE_KEY_SIZE {
-            return false;
+        match Scalar::from_slice(*other) {
+            Ok(other_scalar) => self.scalar == other_scalar,
+            Err(_) => false,
         }
-        // unwrap OK due to valid len
-        let other = Scalar::from_slice(*other).unwrap();
-        self.scalar == other
     }
 }
 


### PR DESCRIPTION
closes #219 

This change introduces custom instantiations of the `PublicKey` and `PrivateKey` newtypes for X25519. Custom in the sense, that these are no longer defined using the newtypes macros in `typedefs`.

`PublicKey` is changed to be a wrapper over a `FieldElement`, which means that the `PartialEq<FieldElement>` impl is used by `PublicKey` now. Creating a `FieldElement` from bytes masks the high-bit and converting it to bytes, gives the representation in canonical form, based on the conversion provided by fiat-crypto. Thus, the new `PartialEq<PublicKey>` impl should now conform to the RFC. As test has also been added to confirm this.

`PrivateKey`  is changed to be a wrapper over a `Scalar`. This means, the value held is no longer raw bytes, but a scalar decoded from bytes, as dictated by the RFC. 
