### PR TITLE
trim serde's enabled features to just `alloc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,12 @@ subtle = { version = "^2.2.2", default-features = false }
 zeroize = { version = "1.1.0", default-features = false }
 getrandom = { version = "0.2.0", optional = true }
 ct-codecs = { version = "1.1.1", optional = true }
-serde = { version = "1.0.124", optional = true }
+
+[dependencies.serde]
+version = "1.0.124"
+optional = true
+default-features = false
+features = ["alloc"]
 
 [features]
 default = [ "safe_api" ]


### PR DESCRIPTION
Serde's feature set mainly defines for which standard-library types it implements Serialize and Deserialize. By default, serde enabels the feature flag "std", which includes container types like Vec, HashMap, etc. However, we only need a subset of these types for Deserialization. That subset is represented by serde's alloc flag.

---

Closes #220 (I think).

This is a small PR that just restricts which subset of serde's features we enable. 

One other thing we may want to consider is having two separate serde flags: one for serialization, and another for deserialization. It could be that serialization is possible in more `no_std` contexts than deserialization. I'd have to look into it more. I'm going to file an issue to investigate that, but in the meantime, I think it's perfectly reasonable to have the one feature flag that enables `serde` and basically requires that some kind of global allcoator is set up.