### PR TITLE
impl standard IO traits for hashing

### DIFF
--- a/src/hazardous/hash/blake2/blake2b.rs
+++ b/src/hazardous/hash/blake2/blake2b.rs
@@ -65,6 +65,9 @@ use crate::errors::UnknownCryptoError;
 use crate::hazardous::hash::blake2::blake2b_core;
 use crate::hazardous::hash::blake2::blake2b_core::BLAKE2B_OUTSIZE;
 
+#[cfg(feature = "safe_api")]
+use std::io;
+
 construct_public! {
     /// A type to represent the `Digest` that BLAKE2b returns.
     ///
@@ -145,6 +148,38 @@ impl Hasher {
             Hasher::Blake2b384 => Blake2b::new(48),
             Hasher::Blake2b512 => Blake2b::new(64),
         }
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+/// Example: custom digest size.
+/// ```rust
+/// use orion::{
+///     hazardous::hash::blake2::blake2b::{Blake2b, Digest},
+///     errors::UnknownCryptoError,
+/// };
+/// use std::io::{self, Read, Write};
+///
+/// // `reader` could also be a `File::open(...)?`.
+/// let mut reader = io::Cursor::new(b"some data");
+/// let mut hasher = Blake2b::new(64)?; // 512-bit hash
+/// std::io::copy(&mut reader, &mut hasher)?;
+///
+/// let digest: Digest = hasher.finalize()?;
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "safe_api")]
+impl io::Write for Blake2b {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.update(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        // This type doesn't buffer writes, so flushing is a no-op.
+        Ok(())
     }
 }
 
@@ -342,6 +377,26 @@ mod public {
             assert!(Blake2b::new(65).is_err());
             assert!(Blake2b::new(1).is_ok());
             assert!(Blake2b::new(64).is_ok());
+        }
+    }
+
+    #[cfg(feature = "safe_api")]
+    mod test_io_impls {
+        use crate::hazardous::hash::blake2::blake2b::Blake2b;
+        use std::io::Write;
+
+        #[quickcheck]
+        fn prop_hasher_write_same_as_update(data: Vec<u8>) -> bool {
+            let mut hasher_a = Blake2b::new(64).unwrap();
+            let mut hasher_b = hasher_a.clone();
+
+            hasher_a.update(&data).unwrap();
+            hasher_b.write_all(&data).unwrap();
+
+            let hash_a = hasher_a.finalize().unwrap();
+            let hash_b = hasher_b.finalize().unwrap();
+
+            hash_a == hash_b
         }
     }
 }

--- a/src/hazardous/hash/blake2/blake2b.rs
+++ b/src/hazardous/hash/blake2/blake2b.rs
@@ -177,8 +177,8 @@ impl io::Write for Blake2b {
         Ok(bytes.len())
     }
 
+    /// This type doesn't buffer writes, so flushing is a no-op.
     fn flush(&mut self) -> Result<(), std::io::Error> {
-        // This type doesn't buffer writes, so flushing is a no-op.
         Ok(())
     }
 }

--- a/src/hazardous/hash/blake2/blake2b.rs
+++ b/src/hazardous/hash/blake2/blake2b.rs
@@ -171,6 +171,16 @@ impl Hasher {
 /// ```
 #[cfg(feature = "safe_api")]
 impl io::Write for Blake2b {
+    /// Update the hasher's internal state with *all* of the bytes given.
+    /// If this function returns the `Ok` variant, it's guaranteed that it
+    /// will contain the length of the buffer passed to [`Write`](std::io::Write).
+    /// Note that this function is just a small wrapper over
+    /// [`Blake2b::update`](crate::hazardous::hash::blake2::blake2b::Blake2b::update).
+    ///
+    /// ## Errors:
+    /// This function will only ever return the [`std::io::ErrorKind::Other`]()
+    /// variant when it returns an error. Additionally, this will always contain Orion's
+    /// [`UnknownCryptoError`](crate::errors::UnknownCryptoError) type.
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
         self.update(bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/src/hazardous/hash/sha2/sha256.rs
+++ b/src/hazardous/hash/sha2/sha256.rs
@@ -233,7 +233,7 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha256 {
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
-/// Example: hashing from a `Read`er with SHA256.
+/// Example: hashing from a [`Read`](std::io::Read)er with SHA256.
 /// ```rust
 /// use orion::{
 ///     hazardous::hash::sha2::sha256::{Sha256, Digest},
@@ -252,6 +252,16 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha256 {
 /// ```
 #[cfg(feature = "safe_api")]
 impl io::Write for Sha256 {
+    /// Update the hasher's internal state with *all* of the bytes given.
+    /// If this function returns the `Ok` variant, it's guaranteed that it
+    /// will contain the length of the buffer passed to [`Write`](std::io::Write).
+    /// Note that this function is just a small wrapper over
+    /// [`Sha256::update`](crate::hazardous::hash::sha2::sha256::Sha256::update).
+    ///
+    /// ## Errors:
+    /// This function will only ever return the [`std::io::ErrorKind::Other`]()
+    /// variant when it returns an error. Additionally, this will always contain Orion's
+    /// [`UnknownCryptoError`](crate::errors::UnknownCryptoError) type.
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
         self.update(bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/src/hazardous/hash/sha2/sha256.rs
+++ b/src/hazardous/hash/sha2/sha256.rs
@@ -61,6 +61,9 @@
 
 use crate::errors::UnknownCryptoError;
 
+#[cfg(feature = "safe_api")]
+use std::io;
+
 /// The blocksize for the hash function SHA256.
 pub const SHA256_BLOCKSIZE: usize = 64;
 /// The output size for the hash function SHA256.
@@ -229,6 +232,38 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha256 {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+/// Example: hashing from a `Read`er with SHA256.
+/// ```rust
+/// use orion::{
+///     hazardous::hash::sha2::sha256::{Sha256, Digest},
+///     errors::UnknownCryptoError,
+/// };
+/// use std::io::{self, Read, Write};
+///
+/// // `reader` could also be a `File::open(...)?`.
+/// let mut reader = io::Cursor::new(b"some data");
+/// let mut hasher = Sha256::new();
+/// std::io::copy(&mut reader, &mut hasher)?;
+///
+/// let digest: Digest = hasher.finalize()?;
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "safe_api")]
+impl io::Write for Sha256 {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.update(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok(bytes.len())
+    }
+
+    /// This type doesn't buffer writes, so flushing is a no-op.
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+
 // Testing public functions in the module.
 #[cfg(test)]
 mod public {
@@ -311,6 +346,26 @@ mod public {
             );
             test_runner.run_all_tests_property(&data);
             true
+        }
+    }
+
+    #[cfg(feature = "safe_api")]
+    mod test_io_impls {
+        use crate::hazardous::hash::sha2::sha256::Sha256;
+        use std::io::Write;
+
+        #[quickcheck]
+        fn prop_hasher_write_same_as_update(data: Vec<u8>) -> bool {
+            let mut hasher_a = Sha256::new();
+            let mut hasher_b = hasher_a.clone();
+
+            hasher_a.update(&data).unwrap();
+            hasher_b.write_all(&data).unwrap();
+
+            let hash_a = hasher_a.finalize().unwrap();
+            let hash_b = hasher_b.finalize().unwrap();
+
+            hash_a == hash_b
         }
     }
 }

--- a/src/hazardous/hash/sha2/sha384.rs
+++ b/src/hazardous/hash/sha2/sha384.rs
@@ -238,8 +238,8 @@ impl io::Write for Sha384 {
         Ok(bytes.len())
     }
 
+    /// This type doesn't buffer writes, so flushing is a no-op.
     fn flush(&mut self) -> Result<(), std::io::Error> {
-        // This type doesn't buffer writes, so flushing is a no-op.
         Ok(())
     }
 }

--- a/src/hazardous/hash/sha2/sha384.rs
+++ b/src/hazardous/hash/sha2/sha384.rs
@@ -213,7 +213,7 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha384 {
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
-/// Example: hashing from a `Read`er with SHA384.
+/// Example: hashing from a [`Read`](std::io::Read)er with SHA384.
 /// ```rust
 /// use orion::{
 ///     hazardous::hash::sha2::sha384::{Sha384, Digest},
@@ -232,6 +232,16 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha384 {
 /// ```
 #[cfg(feature = "safe_api")]
 impl io::Write for Sha384 {
+    /// Update the hasher's internal state with *all* of the bytes given.
+    /// If this function returns the `Ok` variant, it's guaranteed that it
+    /// will contain the length of the buffer passed to [`Write`](std::io::Write).
+    /// Note that this function is just a small wrapper over
+    /// [`Sha384::update`](crate::hazardous::hash::sha2::sha384::Sha384::update).
+    ///
+    /// ## Errors:
+    /// This function will only ever return the [`std::io::ErrorKind::Other`]()
+    /// variant when it returns an error. Additionally, this will always contain Orion's
+    /// [`UnknownCryptoError`](crate::errors::UnknownCryptoError) type.
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
         self.update(bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/src/hazardous/hash/sha2/sha512.rs
+++ b/src/hazardous/hash/sha2/sha512.rs
@@ -261,8 +261,8 @@ impl io::Write for Sha512 {
         Ok(bytes.len())
     }
 
+    /// This type doesn't buffer writes, so flushing is a no-op.
     fn flush(&mut self) -> Result<(), std::io::Error> {
-        // This type doesn't buffer writes, so flushing is a no-op.
         Ok(())
     }
 }

--- a/src/hazardous/hash/sha2/sha512.rs
+++ b/src/hazardous/hash/sha2/sha512.rs
@@ -236,7 +236,7 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha512 {
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
-/// Example: hashing from a `Read`er with SHA512.
+/// Example: hashing from a [`Read`](std::io::Read)er with SHA512.
 /// ```rust
 /// use orion::{
 ///     hazardous::hash::sha2::sha512::{Sha512, Digest},
@@ -255,6 +255,16 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha512 {
 /// ```
 #[cfg(feature = "safe_api")]
 impl io::Write for Sha512 {
+    /// Update the hasher's internal state with *all* of the bytes given.
+    /// If this function returns the `Ok` variant, it's guaranteed that it
+    /// will contain the length of the buffer passed to [`Write`](std::io::Write).
+    /// Note that this function is just a small wrapper over
+    /// [`Sha512::update`](crate::hazardous::hash::sha2::sha512::Sha512::update).
+    ///
+    /// ## Errors:
+    /// This function will only ever return the [`std::io::ErrorKind::Other`]()
+    /// variant when it returns an error. Additionally, this will always contain Orion's
+    /// [`UnknownCryptoError`](crate::errors::UnknownCryptoError) type.
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
         self.update(bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/src/hazardous/hash/sha2/sha512.rs
+++ b/src/hazardous/hash/sha2/sha512.rs
@@ -61,6 +61,9 @@
 
 use crate::errors::UnknownCryptoError;
 
+#[cfg(feature = "safe_api")]
+use std::io;
+
 construct_public! {
     /// A type to represent the `Digest` that SHA512 returns.
     ///
@@ -232,6 +235,38 @@ impl crate::hazardous::mac::hmac::HmacHashFunction for Sha512 {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+/// Example: hashing from a `Read`er with SHA512.
+/// ```rust
+/// use orion::{
+///     hazardous::hash::sha2::sha512::{Sha512, Digest},
+///     errors::UnknownCryptoError,
+/// };
+/// use std::io::{self, Read, Write};
+///
+/// // `reader` could also be a `File::open(...)?`.
+/// let mut reader = io::Cursor::new(b"some data");
+/// let mut hasher = Sha512::new();
+/// std::io::copy(&mut reader, &mut hasher)?;
+///
+/// let digest: Digest = hasher.finalize()?;
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "safe_api")]
+impl io::Write for Sha512 {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.update(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        // This type doesn't buffer writes, so flushing is a no-op.
+        Ok(())
+    }
+}
+
 // Testing public functions in the module.
 #[cfg(test)]
 mod public {
@@ -314,6 +349,26 @@ mod public {
             );
             test_runner.run_all_tests_property(&data);
             true
+        }
+    }
+
+    #[cfg(feature = "safe_api")]
+    mod test_io_impls {
+        use crate::hazardous::hash::sha2::sha512::Sha512;
+        use std::io::Write;
+
+        #[quickcheck]
+        fn prop_hasher_write_same_as_update(data: Vec<u8>) -> bool {
+            let mut hasher_a = Sha512::new();
+            let mut hasher_b = hasher_a.clone();
+
+            hasher_a.update(&data).unwrap();
+            hasher_b.write_all(&data).unwrap();
+
+            let hash_a = hasher_a.finalize().unwrap();
+            let hash_b = hasher_b.finalize().unwrap();
+
+            hash_a == hash_b
         }
     }
 }

--- a/src/high_level/hash.rs
+++ b/src/high_level/hash.rs
@@ -79,19 +79,24 @@ pub fn digest(data: &[u8]) -> Result<Digest, UnknownCryptoError> {
     blake2b::Hasher::Blake2b256.digest(data)
 }
 
-/// Hash data from `impl Read` using BLAKE2b-256.
+/// Hash data from a [`Read`](std::io::Read)` type using BLAKE2b-256.
 ///
 /// See the [module-level docs](crate::hash) for an example of how to use this function.
-/// Internally calls `std::io::copy()` to move data from the reader into the Blake2b writer.
-/// The `std::io::copy` function buffers reads, so passing in a `BufReader` may be unnecessary.
+/// Internally calls [`std::io::copy`]() to move data from the reader into the Blake2b writer.
+/// Note that the [`std::io::copy`]() function buffers reads, so passing in a
+/// [`BufReader`](std::io::BufReader) may be unnecessary.
 ///
 /// For lower-level control over reads, writes, buffer sizes, *etc.*, consider using the
 /// [`Blake2b`](crate::hazardous::hash::blake2::blake2b::Blake2b) type and its
-/// [`Write`](std::io::Write) implementation directly. See the Blake2b type's source code
-/// for an example.
+/// [`Write`](std::io::Write) implementation directly. See `Blake2b`'s `Write` implementation
+/// and/or its `Write` documentation for an example.
 ///
-/// Note that if an error is returned, data may still have been consumed
-/// from the given reader.
+/// ## Errors:
+/// This function will only ever return the [`std::io::ErrorKind::Other`]()
+/// variant when it returns an error. Additionally, this will always contain Orion's
+/// [`UnknownCryptoError`](crate::errors::UnknownCryptoError) type.
+///
+/// Note that if an error is returned, data may still have been consumed from the given reader.
 #[cfg(feature = "safe_api")]
 #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
 pub fn digest_from_reader(mut reader: impl std::io::Read) -> Result<Digest, UnknownCryptoError> {


### PR DESCRIPTION
See #227.

## TODOs
- [ ] Hashing
    - [x] implement from_reader for BLAKE2b
    - [ ] implement from_reader for sha2 (if we feel like we need to)
        - [ ] sha256
        - [ ] sha384
        - [ ] sha512
- [ ] AEAD
    - [ ] implement seal_copy for XChaCha20Poly1305
    - [ ] implement open_copy for XChaCha20Poly1305
    - [ ] Other, non-high-level-interface methods (?)
- [x] General
    - [x] decide whether to keep or change all these function names, like from_reader, seal_copy, open_copy

---

EDIT: The scope of this PR has changed. We were going to try to fit the Read/Write impls for all of Orion's types into this PR, but then decided to split it up. #227 will keep track of all the impls.

Now this PR implements `std::io::Write` for Blake2b and adds a convenience function `orion::hash::digest_from_reader`.
