### PR TITLE
Derive Clone and Copy for StreamTag enum

### DIFF
--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -107,7 +107,7 @@ use core::convert::TryFrom;
 use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, Zeroizing};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// Tag that indicates the type of message.
 pub enum StreamTag {
     /// A message with no special meaning.


### PR DESCRIPTION
This pr simply adds `Clone` and `Copy` to StreamTag enum. More description can be found in issue #211 

This is related to Hacktoberfest :D.