### PR TITLE
Let seal_chunk take reference of StreamTag

### DIFF
--- a/src/high_level/aead.rs
+++ b/src/high_level/aead.rs
@@ -205,10 +205,10 @@ pub mod streaming {
     //!         if src_chunk.len() != chunk_size || n_chunk + 1 == src.len() / chunk_size {
     //!             // We've reached the end of the input source,
     //!             // so we mark it with the Finish tag.
-    //!             sealer.seal_chunk(src_chunk, StreamTag::Finish)?
+    //!             sealer.seal_chunk(src_chunk, &StreamTag::Finish)?
     //!         } else {
     //!             // Just a normal chunk
-    //!             sealer.seal_chunk(src_chunk, StreamTag::Message)?
+    //!             sealer.seal_chunk(src_chunk, &StreamTag::Message)?
     //!         };
     //!     // Save the encrypted chunk somewhere
     //!     out.push(encrypted_chunk);
@@ -263,7 +263,7 @@ pub mod streaming {
         pub fn seal_chunk(
             &mut self,
             plaintext: &[u8],
-            tag: StreamTag,
+            tag: &StreamTag,
         ) -> Result<Vec<u8>, UnknownCryptoError> {
             let sealed_chunk_len = plaintext.len().checked_add(ABYTES);
             if sealed_chunk_len.is_none() {
@@ -414,7 +414,7 @@ mod public {
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let plaintext = "Secret message".as_bytes();
 
-            let dst_ciphertext = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
+            let dst_ciphertext = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
             assert_eq!(dst_ciphertext.len(), plaintext.len() + 17);
             let (dst_plaintext, tag) = opener.open_chunk(&dst_ciphertext).unwrap();
             assert_eq!(plaintext, &dst_plaintext[..]);
@@ -427,7 +427,7 @@ mod public {
             let (mut sealer, _) = StreamSealer::new(&key).unwrap();
             let plaintext = "".as_bytes();
 
-            assert!(sealer.seal_chunk(plaintext, StreamTag::Message).is_ok());
+            assert!(sealer.seal_chunk(plaintext, &StreamTag::Message).is_ok());
         }
 
         #[test]
@@ -446,7 +446,7 @@ mod public {
             let (mut sealer, nonce) = StreamSealer::new(&key).unwrap();
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let ciphertext = sealer
-                .seal_chunk("".as_bytes(), StreamTag::Message)
+                .seal_chunk("".as_bytes(), &StreamTag::Message)
                 .unwrap();
             let (pt, tag) = opener.open_chunk(&ciphertext).unwrap();
 
@@ -461,7 +461,7 @@ mod public {
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let plaintext = "Secret message".as_bytes();
 
-            let mut dst_ciphertext = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
+            let mut dst_ciphertext = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
             // Modify tag
             dst_ciphertext[0] ^= 1;
             assert!(opener.open_chunk(&dst_ciphertext).is_err());
@@ -474,7 +474,7 @@ mod public {
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let plaintext = "Secret message".as_bytes();
 
-            let mut dst_ciphertext = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
+            let mut dst_ciphertext = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
             // Modify ciphertext
             dst_ciphertext[1] ^= 1;
             assert!(opener.open_chunk(&dst_ciphertext).is_err());
@@ -487,7 +487,7 @@ mod public {
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let plaintext = "Secret message".as_bytes();
 
-            let mut dst_ciphertext = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
+            let mut dst_ciphertext = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
             // Modify mac
             let macpos = dst_ciphertext.len() - 1;
             dst_ciphertext[macpos] ^= 1;
@@ -502,7 +502,7 @@ mod public {
             let bad_key = SecretKey::default();
             let mut opener = StreamOpener::new(&bad_key, &nonce).unwrap();
 
-            let dst_ciphertext = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
+            let dst_ciphertext = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
 
             assert!(opener.open_chunk(&dst_ciphertext).is_err());
         }
@@ -519,8 +519,8 @@ mod public {
             let key = SecretKey::default();
             let (mut sealer, nonce) = StreamSealer::new(&key).unwrap();
             let plaintext = "Secret message 1".as_bytes();
-            let cipher1 = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
-            let cipher2 = sealer.seal_chunk(plaintext, StreamTag::Message).unwrap();
+            let cipher1 = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
+            let cipher2 = sealer.seal_chunk(plaintext, &StreamTag::Message).unwrap();
             assert_ne!(cipher1, cipher2);
 
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
@@ -543,10 +543,10 @@ mod public {
             let plaintext = "Secret message 1".as_bytes();
 
             let cipher1 = sealer_first
-                .seal_chunk(plaintext, StreamTag::Message)
+                .seal_chunk(plaintext, &StreamTag::Message)
                 .unwrap();
             let cipher2 = sealer_second
-                .seal_chunk(plaintext, StreamTag::Message)
+                .seal_chunk(plaintext, &StreamTag::Message)
                 .unwrap();
             assert_ne!(cipher1, cipher2);
         }
@@ -558,9 +558,9 @@ mod public {
             let plaintext1 = "Secret message 1".as_bytes();
             let plaintext2 = "Secret message 2".as_bytes();
             let plaintext3 = "Secret message 3".as_bytes();
-            let cipher1 = sealer.seal_chunk(plaintext1, StreamTag::Message).unwrap();
-            let cipher2 = sealer.seal_chunk(plaintext2, StreamTag::Finish).unwrap();
-            let cipher3 = sealer.seal_chunk(plaintext3, StreamTag::Message).unwrap();
+            let cipher1 = sealer.seal_chunk(plaintext1, &StreamTag::Message).unwrap();
+            let cipher2 = sealer.seal_chunk(plaintext2, &StreamTag::Finish).unwrap();
+            let cipher3 = sealer.seal_chunk(plaintext3, &StreamTag::Message).unwrap();
 
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let (dec1, tag1) = opener.open_chunk(&cipher1).unwrap();
@@ -580,7 +580,7 @@ mod public {
             let key = SecretKey::default();
 
             let (mut sealer, nonce) = StreamSealer::new(&key).unwrap();
-            let ct = sealer.seal_chunk(&input[..], StreamTag::Message).unwrap();
+            let ct = sealer.seal_chunk(&input[..], &StreamTag::Message).unwrap();
 
             let mut opener = StreamOpener::new(&key, &nonce).unwrap();
             let (pt_decrypted, tag) = opener.open_chunk(&ct).unwrap();

--- a/tests/aead/pynacl_streaming_aead.rs
+++ b/tests/aead/pynacl_streaming_aead.rs
@@ -50,7 +50,7 @@ fn run_tests_from_json(path_to_vectors: &str) {
                     &chunk_msg,
                     Some(&chunk_ad),
                     &mut chunk_out_ct,
-                    StreamTag::try_from(chunk.tag).unwrap(),
+                    &StreamTag::try_from(chunk.tag).unwrap(),
                 )
                 .unwrap();
 


### PR DESCRIPTION
This pr is related to issue #212.
Thanks to rust compiler, I changed function signature first then fix some errors caused by `cargo check`, `cargo clippy` and `cargo test`