### PR TITLE
Use `doc_cfg` to render feature badges for feature-gated functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ harness = false
 [profile.dev]
 opt-level = 1
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/high_level/aead.rs
+++ b/src/high_level/aead.rs
@@ -78,6 +78,8 @@
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 
+#![cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+
 pub use super::hltypes::SecretKey;
 use crate::{
     errors::UnknownCryptoError,

--- a/src/high_level/auth.rs
+++ b/src/high_level/auth.rs
@@ -69,6 +69,8 @@
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 
+#![cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+
 pub use super::hltypes::{SecretKey, Tag};
 use crate::{
     errors::UnknownCryptoError,

--- a/src/high_level/hash.rs
+++ b/src/high_level/hash.rs
@@ -54,6 +54,8 @@
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 
+#![cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+
 pub use crate::hazardous::hash::blake2b::Digest;
 use crate::{errors::UnknownCryptoError, hazardous::hash::blake2b};
 

--- a/src/high_level/kdf.rs
+++ b/src/high_level/kdf.rs
@@ -71,6 +71,8 @@
 //! ```
 //! [libsodium's docs]: https://download.libsodium.org/doc/password_hashing/default_phf#guidelines-for-choosing-the-parameters
 
+#![cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+
 pub use super::hltypes::{Password, Salt, SecretKey};
 use crate::{errors::UnknownCryptoError, hazardous::kdf::argon2i, pwhash::MIN_ITERATIONS};
 

--- a/src/high_level/kex.rs
+++ b/src/high_level/kex.rs
@@ -82,6 +82,8 @@
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 
+#![cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+
 pub use super::hltypes::SecretKey;
 pub use crate::hazardous::ecc::x25519::PrivateKey;
 pub use crate::hazardous::ecc::x25519::PublicKey;

--- a/src/high_level/pwhash.rs
+++ b/src/high_level/pwhash.rs
@@ -87,6 +87,8 @@
 //! [encoding format here]: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
 //! [libsodium's docs]: https://download.libsodium.org/doc/password_hashing/default_phf#guidelines-for-choosing-the-parameters
 
+#![cfg_attr(docsrs, doc(cfg(feature = "safe_api")))]
+
 pub use super::hltypes::Password;
 use super::hltypes::Salt;
 use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
     overflowing_literals
 )]
 #![doc(html_root_url = "https://docs.rs/orion/0.16.0")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(test)]
 #[cfg(feature = "safe_api")]


### PR DESCRIPTION
fixes #238 

`RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --no-deps --all-features --open`

Screenshots:
<img width="1433" alt="ss1" src="https://user-images.githubusercontent.com/34031846/139579270-62738822-ab51-4f84-a9f3-506e49cc1ab1.png">
<img width="1433" alt="ss2" src="https://user-images.githubusercontent.com/34031846/139579276-edbd4173-7885-4cc2-ade2-beea7228b0aa.png">
<img width="1435" alt="ss3" src="https://user-images.githubusercontent.com/34031846/139579277-fbbe3028-5afe-47b9-b835-9f6d6d8035c2.png">
<img width="1433" alt="ss4" src="https://user-images.githubusercontent.com/34031846/139579280-5e25a812-4a98-4b97-8b3b-f89bef7d1afe.png">

