### PR TITLE
CI: Ignore `serde_cbor` unmaintained advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+# serde_cbor is unmaintained, used in criterion.
+# See https://github.com/bheisler/criterion.rs/issues/534
+ignore = [ "RUSTSEC-2021-0127" ]

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,11 @@ yanked = "deny"
 notice = "deny"
 unsound = "deny"
 vulnerability = "deny"
+ignore = [
+    # serde_cbor is unmaintained, used in criterion.
+    # See https://github.com/bheisler/criterion.rs/issues/534
+    "RUSTSEC-2021-0127",
+]
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
`serde_cbor` is used by `criterion` for benchmarking only, so we want to avoid failing builds due to this advisory only. Issue at `criterion` to switch to an alternative: https://github.com/bheisler/criterion.rs/issues/534