### PR TITLE
CI: Add `audit-check` to Actions workflow

### DIFF
--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -1,0 +1,17 @@
+name: Security audit (audit-check)
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -1,6 +1,7 @@
 name: Security audit (audit-check)
 permissions:
   contents: read
+  issues: write
 
 on:
   schedule:


### PR DESCRIPTION
closes #251, #257

This adds the `audit-check` action to our workflow. This should create issues if vulnerable dependencies show up during the run, instead of just the current action failing and sending me an email. It should also fix #251.

We will keep the previous cargo audit check as well because, as mentioned in #257, it seems unclear how much support this `audit-check` action is receiving. 