### PR TITLE
Feature-gate doc examples to enable doctests on `--no-default-features` builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         with:
           command: test
-          args: --no-default-features --tests
+          args: --no-default-features
       
       - name: Test debug-mode, alloc feature
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
@@ -81,7 +81,7 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         with:
           command: test
-          args: --release --no-default-features --tests
+          args: --release --no-default-features
       
       - name: Test release-mode, alloc feature
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Before submitting a pull request, please make sure you have done the following:
 - [ ] Ensure that all tests pass when running:
   
   - `cargo test`
-  - `cargo +nightly test --tests --no-default-features`
+  - `cargo +nightly test --no-default-features`
 
 - [ ] The formatting is correct and clippy does not show warnings by running:
 

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -90,7 +90,8 @@
 //! aead::chacha20poly1305::open(&secret_key, &nonce, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt.as_ref(), message.as_ref());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`XChaCha20Poly1305`]: xchacha20poly1305

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -68,6 +68,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::aead;
 //!
 //! let secret_key = aead::chacha20poly1305::SecretKey::generate();
@@ -89,7 +90,7 @@
 //! aead::chacha20poly1305::open(&secret_key, &nonce, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt.as_ref(), message.as_ref());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`XChaCha20Poly1305`]: xchacha20poly1305

--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -58,6 +58,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::aead::streaming::*;
 //!
 //! let secret_key = SecretKey::generate();
@@ -82,7 +83,7 @@
 //!
 //! assert_eq!(tag, StreamTag::Message);
 //! assert_eq!(dst_out_pt.as_ref(), message);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`Nonce::generate()`]: super::stream::xchacha20::Nonce::generate

--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -83,7 +83,8 @@
 //!
 //! assert_eq!(tag, StreamTag::Message);
 //! assert_eq!(dst_out_pt.as_ref(), message);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`Nonce::generate()`]: super::stream::xchacha20::Nonce::generate

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -78,7 +78,8 @@
 //! aead::xchacha20poly1305::open(&secret_key, &nonce, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt.as_ref(), message.as_ref());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`Nonce::generate()`]: super::stream::xchacha20::Nonce::generate

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -59,6 +59,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::aead;
 //!
 //! let secret_key = aead::xchacha20poly1305::SecretKey::generate();
@@ -77,7 +78,7 @@
 //! aead::xchacha20poly1305::open(&secret_key, &nonce, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt.as_ref(), message.as_ref());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`Nonce::generate()`]: super::stream::xchacha20::Nonce::generate

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -56,7 +56,8 @@
 //! let bob_shared = key_agreement(&bob_sk, &alice_pk)?;
 //!
 //! assert_eq!(alice_shared, bob_shared);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`PrivateKey::generate()`]: crate::hazardous::ecc::x25519::PrivateKey::generate
 //! [`orion::kex`]: crate::kex
@@ -505,7 +506,9 @@ impl PublicKey {
 /// assert_ne!(secret_key, &[0; 32][..]);
 ///
 /// // Secure, constant-time comparison with another SecretKey
-/// assert_ne!(secret_key, PrivateKey::generate()); }
+/// assert_ne!(secret_key, PrivateKey::generate());
+/// # }
+/// # Ok::<(), orion::errors::UnknownCryptoError>(())
 /// ```
 #[derive(PartialEq)]
 pub struct PrivateKey {

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -39,6 +39,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::ecc::x25519::{PrivateKey, PublicKey, SharedKey, key_agreement};
 //! use core::convert::TryFrom;
 //!
@@ -55,7 +56,7 @@
 //! let bob_shared = key_agreement(&bob_sk, &alice_pk)?;
 //!
 //! assert_eq!(alice_shared, bob_shared);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`PrivateKey::generate()`]: crate::hazardous::ecc::x25519::PrivateKey::generate
 //! [`orion::kex`]: crate::kex
@@ -494,6 +495,7 @@ impl PublicKey {
 /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
 /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
 /// ```rust
+/// # #[cfg(feature = "safe_api")] {
 /// use orion::hazardous::ecc::x25519::PrivateKey;
 ///
 /// // Initialize a secret key with random bytes.
@@ -503,7 +505,7 @@ impl PublicKey {
 /// assert_ne!(secret_key, &[0; 32][..]);
 ///
 /// // Secure, constant-time comparison with another SecretKey
-/// assert_ne!(secret_key, PrivateKey::generate());
+/// assert_ne!(secret_key, PrivateKey::generate()); }
 /// ```
 #[derive(PartialEq)]
 pub struct PrivateKey {

--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -65,6 +65,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::{hazardous::kdf::argon2i, util};
 //!
 //! let mut salt = [0u8; 16];
@@ -87,7 +88,7 @@
 //!     &mut dst_out
 //! )
 //! .is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`secure_rand_bytes()`]: crate::util::secure_rand_bytes
 //! [`zeroize` crate]: https://crates.io/crates/zeroize

--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -88,7 +88,8 @@
 //!     &mut dst_out
 //! )
 //! .is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`secure_rand_bytes()`]: crate::util::secure_rand_bytes
 //! [`zeroize` crate]: https://crates.io/crates/zeroize

--- a/src/hazardous/kdf/hkdf.rs
+++ b/src/hazardous/kdf/hkdf.rs
@@ -42,6 +42,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::{hazardous::kdf::hkdf, util};
 //!
 //! let mut salt = [0u8; 64];
@@ -50,7 +51,7 @@
 //!
 //! hkdf::sha512::derive_key(&salt, "IKM".as_bytes(), None, &mut okm_out)?;
 //!
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`secure_rand_bytes()`]: crate::util::secure_rand_bytes
 

--- a/src/hazardous/kdf/hkdf.rs
+++ b/src/hazardous/kdf/hkdf.rs
@@ -51,7 +51,8 @@
 //!
 //! hkdf::sha512::derive_key(&salt, "IKM".as_bytes(), None, &mut okm_out)?;
 //!
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`secure_rand_bytes()`]: crate::util::secure_rand_bytes
 

--- a/src/hazardous/kdf/pbkdf2.rs
+++ b/src/hazardous/kdf/pbkdf2.rs
@@ -66,7 +66,8 @@
 //! let expected_dk = dst_out;
 //!
 //! assert!(pbkdf2::sha512::verify(&expected_dk, &password, &salt, 10000, &mut dst_out).is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`Password::generate()`]: pbkdf2::sha512::Password::generate
 //! [`secure_rand_bytes()`]: crate::util::secure_rand_bytes

--- a/src/hazardous/kdf/pbkdf2.rs
+++ b/src/hazardous/kdf/pbkdf2.rs
@@ -53,6 +53,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::{hazardous::kdf::pbkdf2, util};
 //!
 //! let mut salt = [0u8; 64];
@@ -65,7 +66,7 @@
 //! let expected_dk = dst_out;
 //!
 //! assert!(pbkdf2::sha512::verify(&expected_dk, &password, &salt, 10000, &mut dst_out).is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`Password::generate()`]: pbkdf2::sha512::Password::generate
 //! [`secure_rand_bytes()`]: crate::util::secure_rand_bytes

--- a/src/hazardous/mac/blake2b.rs
+++ b/src/hazardous/mac/blake2b.rs
@@ -58,7 +58,8 @@
 //! let tag = state.finalize()?;
 //!
 //! assert!(Blake2b::verify(&tag, &key, 64, b"Some data").is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`update()`]: blake2b::Blake2b::update
 //! [`reset()`]: blake2b::Blake2b::reset

--- a/src/hazardous/mac/blake2b.rs
+++ b/src/hazardous/mac/blake2b.rs
@@ -48,6 +48,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::mac::blake2b::{Blake2b, SecretKey};
 //!
 //! let key = SecretKey::generate();
@@ -57,7 +58,7 @@
 //! let tag = state.finalize()?;
 //!
 //! assert!(Blake2b::verify(&tag, &key, 64, b"Some data").is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`update()`]: blake2b::Blake2b::update
 //! [`reset()`]: blake2b::Blake2b::reset

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -43,6 +43,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::mac::hmac::sha512::{HmacSha512, SecretKey};
 //!
 //! let key = SecretKey::generate();
@@ -52,7 +53,7 @@
 //! let tag = state.finalize()?;
 //!
 //! assert!(HmacSha512::verify(&tag, &key, b"Some message.").is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`update()`]: hmac::sha512::HmacSha512::update
 //! [`reset()`]: hmac::sha512::HmacSha512::reset

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -53,7 +53,8 @@
 //! let tag = state.finalize()?;
 //!
 //! assert!(HmacSha512::verify(&tag, &key, b"Some message.").is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`update()`]: hmac::sha512::HmacSha512::update
 //! [`reset()`]: hmac::sha512::HmacSha512::reset

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -49,6 +49,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::mac::poly1305::{OneTimeKey, Poly1305};
 //!
 //! let one_time_key = OneTimeKey::generate();
@@ -59,7 +60,7 @@
 //! let tag = poly1305_state.finalize()?;
 //!
 //! assert!(Poly1305::verify(&tag, &one_time_key, msg.as_bytes()).is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`update()`]: poly1305::Poly1305::update
 //! [`reset()`]: poly1305::Poly1305::reset

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -60,7 +60,8 @@
 //! let tag = poly1305_state.finalize()?;
 //!
 //! assert!(Poly1305::verify(&tag, &one_time_key, msg.as_bytes()).is_ok());
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`update()`]: poly1305::Poly1305::update
 //! [`reset()`]: poly1305::Poly1305::reset

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -86,7 +86,8 @@
 //! chacha20::decrypt(&secret_key, &nonce, 0, &dst_out_ct, &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt, message);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: chacha20::SecretKey::generate()
 //! [`XChaCha20Poly1305`]: super::aead::xchacha20poly1305

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -66,6 +66,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::stream::chacha20;
 //!
 //! let secret_key = chacha20::SecretKey::generate();
@@ -85,7 +86,7 @@
 //! chacha20::decrypt(&secret_key, &nonce, 0, &dst_out_ct, &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt, message);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`SecretKey::generate()`]: chacha20::SecretKey::generate()
 //! [`XChaCha20Poly1305`]: super::aead::xchacha20poly1305

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -76,7 +76,8 @@
 //! xchacha20::decrypt(&secret_key, &nonce, 0, &dst_out_ct, &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt, message);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+//! # }
+//! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: xchacha20::SecretKey::generate()
 //! [`Nonce::generate()`]: xchacha20::Nonce::generate()

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -59,6 +59,7 @@
 //!
 //! # Example:
 //! ```rust
+//! # #[cfg(feature = "safe_api")] {
 //! use orion::hazardous::stream::xchacha20;
 //!
 //! let secret_key = xchacha20::SecretKey::generate();
@@ -75,7 +76,7 @@
 //! xchacha20::decrypt(&secret_key, &nonce, 0, &dst_out_ct, &mut dst_out_pt)?;
 //!
 //! assert_eq!(dst_out_pt, message);
-//! # Ok::<(), orion::errors::UnknownCryptoError>(())
+//! # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 //! ```
 //! [`SecretKey::generate()`]: xchacha20::SecretKey::generate()
 //! [`Nonce::generate()`]: xchacha20::Nonce::generate()

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -495,6 +495,7 @@ macro_rules! construct_secret_key {
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
+        /// # #[cfg(feature = "safe_api")] {
         /// use orion::hazardous::stream::chacha20::SecretKey;
         ///
         /// // Initialize a secret key with random bytes.
@@ -504,7 +505,7 @@ macro_rules! construct_secret_key {
         /// assert_ne!(secret_key, &[0; 32][..]);
         ///
         /// // Secure, constant-time comparison with another SecretKey
-        /// assert_ne!(secret_key, SecretKey::generate());
+        /// assert_ne!(secret_key, SecretKey::generate()); }
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -808,6 +809,7 @@ macro_rules! construct_hmac_key {
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
+        /// # #[cfg(feature = "safe_api")] {
         /// use orion::hazardous::mac::hmac::sha512::SecretKey;
         ///
         /// // Initialize a secret key with random bytes.
@@ -817,7 +819,7 @@ macro_rules! construct_hmac_key {
         /// assert_ne!(secret_key, &[0; 32][..]);
         ///
         /// // Secure, constant-time comparison with another SecretKey
-        /// assert_ne!(secret_key, SecretKey::generate());
+        /// assert_ne!(secret_key, SecretKey::generate()); }
         /// ```
         pub struct $name {
             value: [u8; $size],

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -505,7 +505,9 @@ macro_rules! construct_secret_key {
         /// assert_ne!(secret_key, &[0; 32][..]);
         ///
         /// // Secure, constant-time comparison with another SecretKey
-        /// assert_ne!(secret_key, SecretKey::generate()); }
+        /// assert_ne!(secret_key, SecretKey::generate());
+        /// # }
+        /// # Ok::<(), orion::errors::UnknownCryptoError>(())
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -556,6 +558,7 @@ macro_rules! construct_secret_key {
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
+        /// # #[cfg(feature = "safe_api")] {
         /// use orion::hazardous::stream::chacha20::SecretKey;
         ///
         /// // Initialize a secret key with random bytes.
@@ -566,6 +569,8 @@ macro_rules! construct_secret_key {
         ///
         /// // Secure, constant-time comparison with another SecretKey
         /// assert_ne!(secret_key, SecretKey::generate());
+        /// # }
+        /// # Ok::<(), orion::errors::UnknownCryptoError>(())
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -734,9 +739,7 @@ macro_rules! construct_tag {
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
         /// use orion::hazardous::mac::hmac::sha512::Tag;
-        /// # use orion::errors::UnknownCryptoError;
         ///
-        /// # fn main() -> Result<(), Box<UnknownCryptoError>> {
         /// // Initialize an arbitrary, 64-byte tag.
         /// let tag = Tag::from_slice(&[1; 64])?;
         ///
@@ -745,8 +748,7 @@ macro_rules! construct_tag {
         ///
         /// // Secure, constant-time comparison with another Tag
         /// assert_eq!(tag, Tag::from_slice(&[1; 64])?);
-        /// # Ok(())
-        /// # }
+        /// # Ok::<(), orion::errors::UnknownCryptoError>(())
         /// ```
         pub struct $name {
             value: [u8; $upper_bound],
@@ -819,7 +821,9 @@ macro_rules! construct_hmac_key {
         /// assert_ne!(secret_key, &[0; 32][..]);
         ///
         /// // Secure, constant-time comparison with another SecretKey
-        /// assert_ne!(secret_key, SecretKey::generate()); }
+        /// assert_ne!(secret_key, SecretKey::generate());
+        /// # }
+        /// # Ok::<(), orion::errors::UnknownCryptoError>(())
         /// ```
         pub struct $name {
             value: [u8; $size],
@@ -897,10 +901,9 @@ macro_rules! construct_secret_key_variable_size {
         /// prefer `SecretType == &[u8]` over `SecretType.unprotected_as_bytes() == &[u8]`.
         /// Examples are shown below. The examples apply to any type that implements `PartialEq<&'_ [u8]>`.
         /// ```rust
+        /// # #[cfg(feature = "safe_api")] {
         /// use orion::pwhash::Password;
-        /// # use orion::errors::UnknownCryptoError;
         ///
-        /// # fn main() -> Result<(), Box<UnknownCryptoError>> {
         /// // Initialize a password with 32 random bytes.
         /// let password = Password::generate(32)?;
         ///
@@ -909,9 +912,8 @@ macro_rules! construct_secret_key_variable_size {
         ///
         /// // Secure, constant-time comparison with another Password
         /// assert_ne!(password, Password::generate(32)?);
-        /// #
-        /// # Ok(())
         /// # }
+        /// # Ok::<(), orion::errors::UnknownCryptoError>(())
         /// ```
         pub struct $name {
             pub(crate) value: Vec<u8>,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -101,6 +101,7 @@ pub fn secure_rand_bytes(dst: &mut [u8]) -> Result<(), errors::UnknownCryptoErro
 ///
 /// # Example:
 /// ```rust
+/// # #[cfg(feature = "safe_api")] {
 /// use orion::util;
 ///
 /// let mut rnd_bytes = [0u8; 64];
@@ -108,7 +109,7 @@ pub fn secure_rand_bytes(dst: &mut [u8]) -> Result<(), errors::UnknownCryptoErro
 ///
 /// util::secure_rand_bytes(&mut rnd_bytes)?;
 /// assert!(util::secure_cmp(&rnd_bytes, &[0u8; 64]).is_err());
-/// # Ok::<(), orion::errors::UnknownCryptoError>(())
+/// # Ok::<(), orion::errors::UnknownCryptoError>(()) }
 /// ```
 pub fn secure_cmp(a: &[u8], b: &[u8]) -> Result<(), errors::UnknownCryptoError> {
     if a.ct_eq(b).into() {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -109,7 +109,8 @@ pub fn secure_rand_bytes(dst: &mut [u8]) -> Result<(), errors::UnknownCryptoErro
 ///
 /// util::secure_rand_bytes(&mut rnd_bytes)?;
 /// assert!(util::secure_cmp(&rnd_bytes, &[0u8; 64]).is_err());
-/// # Ok::<(), orion::errors::UnknownCryptoError>(()) }
+/// # }
+/// # Ok::<(), orion::errors::UnknownCryptoError>(())
 /// ```
 pub fn secure_cmp(a: &[u8], b: &[u8]) -> Result<(), errors::UnknownCryptoError> {
     if a.ct_eq(b).into() {


### PR DESCRIPTION
closes #254 

Add feature-gating to doctests that make use of `safe-api` functionality. Additionally, remove `--tests` flag from `--no-default-features` builds in CI, in order to test that doctests run successfully on `no-std` builds.