### PR TITLE
Capitalize crate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --no-deps --all-features
 ```
 
 ### Tests and Fuzzing
-The [wiki](https://github.com/orion-rs/orion/wiki/Testing-suite) has details on how orion is tested. To run all tests:
+The [wiki](https://github.com/orion-rs/orion/wiki/Testing-suite) has details on how Orion is tested. To run all tests:
 ```
 cargo test
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ The following are threats, which are considered out-of-scope for Orion.
 [1] Wiping sensitive memory is performed on a best-effort approach. However, sensitive memory being wiped or not leaked, cannot be guaranteed. See more in the [wiki](https://github.com/orion-rs/orion/wiki/Security#memory).
 
 ### Supported versions
-Currently, only the latest version, released on [crates.io](https://crates.io/crates/orion), recieves testing and is supported with security fixes.
+Currently, only the latest version, released on [crates.io](https://crates.io/crates/orion), receives testing and is supported with security fixes.
 
 There is no guarantee that a version, containing a security fix, will be SemVer-compatible to the previous one.
 
@@ -30,7 +30,7 @@ Backporting security fixes to older versions will be considered on an ad hoc bas
 Any version which is affected by a security issue, will be yanked. Even though we try to provide it, there is no guarantee that a SemVer-compatible version, containing a fix, will be available at the time of yanking.
 
 ### Recommended best practices
-The are recommendations on how to use Orion correctly:
+These are recommendations on how to use Orion correctly:
 
 - Use `cargo audit` to ensure the current version has no published security vulnerabilities
 - Never use `opt-level=0`, always build in release mode

--- a/src/high_level/pwhash.rs
+++ b/src/high_level/pwhash.rs
@@ -372,7 +372,7 @@ impl_ct_partialeq_trait!(PasswordHash, unprotected_as_bytes);
 
 #[cfg(feature = "serde")]
 /// `PasswordHash` serializes as would a [`String`](std::string::String). Note that
-/// the serialized type likely does not have the same protections that orion
+/// the serialized type likely does not have the same protections that Orion
 /// provides, such as constant-time operations. A good rule of thumb is to only
 /// serialize these types for storage. Don't operate on the serialized types.
 impl Serialize for PasswordHash {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,9 @@
 //! [`orion::kex`] offers ephemeral key exchange using X25519 and BLAKE2b.
 //!
 //! ### A note on `no_std`:
-//! When orion is used in a `no_std` context, the high-level API is not available, since it relies on access to the systems random number generator.
+//! When Orion is used in a `no_std` context, the high-level API is not available, since it relies on access to the systems random number generator.
 //!
-//! More information about orion is available in the [wiki].
+//! More information about Orion is available in the [wiki].
 //!
 //! [`orion::aead`]: crate::aead
 //! [`orion::pwhash`]: crate::pwhash
@@ -86,7 +86,7 @@ mod typedefs;
 /// Utilities such as constant-time comparison.
 pub mod util;
 
-/// Errors for orion's cryptographic operations.
+/// Errors for Orion's cryptographic operations.
 pub mod errors;
 
 /// \[__**Caution**__\] Low-level API.

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -91,7 +91,7 @@ macro_rules! impl_serde_traits (($name:ident, $bytes_function:ident) => (
 
     #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
     /// This type tries to serialize as a `&[u8]` would. Note that the serialized
-    /// type likely does not have the same protections that orion provides, such
+    /// type likely does not have the same protections that Orion provides, such
     /// as constant-time operations. A good rule of thumb is to only serialize
     /// these types for storage. Don't operate on the serialized types.
     impl serde::Serialize for $name {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -45,7 +45,7 @@ pub(crate) mod u64x4;
 /// # About:
 /// This function can be used to generate cryptographic keys, salts or other
 /// values that rely on strong randomness. Please note that most keys and other
-/// types used throughout orion, implement their own `generate()` function and
+/// types used throughout Orion, implement their own `generate()` function and
 /// it is strongly preferred to use those, compared to [`secure_rand_bytes()`].
 ///
 /// This uses [`getrandom`].

--- a/tests/aead/mod.rs
+++ b/tests/aead/mod.rs
@@ -85,7 +85,7 @@ fn wycheproof_test_runner(
                 let is_tag_same = dst_ct_out[input.len()..].as_ref() == tag;
                 let is_decrypted_same = dst_pt_out[..].as_ref() == input;
                 // In this case a test vector reported as invalid by Wycheproof would be
-                // accepted by orion.
+                // accepted by Orion.
                 if is_ct_same && is_decrypted_same && is_tag_same {
                     panic!("Un-allowed test result! {:?}", tcid);
                 }

--- a/tests/mac/nist_cavp_hmac.rs
+++ b/tests/mac/nist_cavp_hmac.rs
@@ -30,7 +30,7 @@ fn test_nist_cavp() {
         match test_case {
             Some(ref tc) => {
                 if current_variant.is_empty() {
-                    // We've found a test case and parse it, but Orion
+                    // We've found a test case and parsed it, but Orion
                     // doesn't support the variant.
                     continue;
                 }


### PR DESCRIPTION
Also additional spelling corrections. I took care of the wiki a couple of days ago.