### PR TITLE
Allow `Unicode-DFS-2016` license in dev-dependency tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,11 @@ allow = [
     "BSD-3-Clause",
     "Apache-2.0",
 ]
+exceptions = [
+    { allow = [
+        "Unicode-DFS-2016",
+    ], name = "unicode-ident" },
+]
 
 [bans]
 multiple-versions = "allow" # We don't maintain Cargo lockfile, so this isn't really feasible to deny


### PR DESCRIPTION
See #289 