### PR TITLE
Remove unmaintained `audit-check` and replace with `cargo-deny`

### DIFF
--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -1,18 +1,30 @@
-name: Security audit (audit-check)
+name: cargo deny (licenses, advisories, sources)
 permissions:
   contents: read
   issues: write
 
 on:
+  push:
+    # Check immediately if dependencies are altered
+    paths:
+      - '**/Cargo.toml'
+    # Check also at midnight each day
   schedule:
     - cron: '0 0 * * *'
+
 jobs:
-  audit:
+  cargo-deny:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          persist-credentials: false
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      with:
+        persist-credentials: false
+    - uses: EmbarkStudios/cargo-deny-action@7257a18a9c2fe3f92b85d41ae473520dff953c97
+      with:
+        command: check ${{ matrix.checks }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,22 +197,3 @@ jobs:
         with:
           command: doc
           args: --no-deps --all-features
-  
-  cargo-deny:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-
-    steps:
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      with:
-        persist-credentials: false
-    - uses: EmbarkStudios/cargo-deny-action@30ecad1d5873c1cc2cad10a33637371ca094768b
-      with:
-        command: check ${{ matrix.checks }}


### PR DESCRIPTION
`audit-check` has not seen any activity since 2020. We replace its functionality with `cargo-deny`.

Also bump `cargo-deny` action to `1.3.2`.