### PR TITLE
Improve `Blake2b::new()` docs

### DIFF
--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -510,7 +510,7 @@ pub struct PrivateKey {
 
 impl PartialEq<&[u8]> for PrivateKey {
     fn eq(&self, other: &&[u8]) -> bool {
-        match Scalar::from_slice(*other) {
+        match Scalar::from_slice(other) {
             Ok(other_scalar) => self.scalar == other_scalar,
             Err(_) => false,
         }

--- a/src/hazardous/hash/blake2/blake2b.rs
+++ b/src/hazardous/hash/blake2/blake2b.rs
@@ -86,7 +86,7 @@ pub struct Blake2b {
 
 impl Blake2b {
     #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-    /// Initialize a `Blake2b` struct with a given size.
+    /// Initialize a `Blake2b` struct with a given size (in bytes).
     pub fn new(size: usize) -> Result<Self, UnknownCryptoError> {
         Ok(Self {
             _state: blake2b_core::State::_new(&[], size)?,

--- a/src/hazardous/mac/blake2b.rs
+++ b/src/hazardous/mac/blake2b.rs
@@ -104,7 +104,7 @@ pub struct Blake2b {
 
 impl Blake2b {
     #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-    /// Initialize a `Blake2b` struct with a given size and key.
+    /// Initialize a `Blake2b` struct with a given size (in bytes) and key.
     pub fn new(secret_key: &SecretKey, size: usize) -> Result<Self, UnknownCryptoError> {
         Ok(Self {
             _state: blake2b_core::State::_new(secret_key.unprotected_as_bytes(), size)?,

--- a/src/high_level/pwhash.rs
+++ b/src/high_level/pwhash.rs
@@ -311,7 +311,7 @@ impl PasswordHash {
         if salt.len() != SALT_LENGTH {
             return Err(UnknownCryptoError);
         }
-        let password_hash_raw = Base64NoPadding::decode_to_vec(&parts.next().unwrap(), None)?;
+        let password_hash_raw = Base64NoPadding::decode_to_vec(parts.next().unwrap(), None)?;
         if password_hash_raw.len() != PWHASH_LENGTH {
             return Err(UnknownCryptoError);
         }


### PR DESCRIPTION
Improve the docs for the `Blake2b::new()` function, by specifying that the `size` parameter is in bytes. Additionally, some clippy suggestions.