### PR TITLE
ci: Add benchmark check test without running any actual benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,3 +197,19 @@ jobs:
         with:
           command: doc
           args: --no-deps --all-features
+  
+  benches:
+    name: Build and check benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        with:
+          persist-credentials: false
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
+        with:
+          command: test
+          args: --benches


### PR DESCRIPTION
This adds a test of the benchmarks, to ensure they are up to date, in case the API changes. It doesn't run any actual benchmarks.