### PR TITLE
(X)ChaCha20/(X)ChaCha20-Poly1305: Do not copy plaintext to `dst_out` before all needed keystream blocks are guaranteed to be produced

### DIFF
--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -180,6 +180,7 @@ pub fn seal(
     }
 
     let ad = ad.unwrap_or(&[0u8; 0]);
+    #[allow(clippy::absurd_extreme_comparisons)]
     if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
         return Err(UnknownCryptoError);
     }
@@ -271,6 +272,7 @@ pub fn open(
         return Err(UnknownCryptoError);
     }
     let ad = ad.unwrap_or(&[0u8; 0]);
+    #[allow(clippy::absurd_extreme_comparisons)]
     if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
         return Err(UnknownCryptoError);
     }

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -199,7 +199,7 @@ pub fn seal(
                     if p_block.len() == CHACHA_BLOCKSIZE && c_block.len() == CHACHA_BLOCKSIZE {
                         stream.keystream_block(counter, c_block);
                         xor_slices!(p_block, c_block);
-                        auth_ctx.update(&c_block)?;
+                        auth_ctx.update(c_block)?;
                     }
 
                     // We only pad this last block to the Poly1305 blocksize since `CHACHA_BLOCKSIZE`

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -40,6 +40,9 @@
 //! counter encrypted with block ciphers with 128-bit or 256-bit blocks,
 //! because such a truncation may repeat after a short time." See [RFC] for more information.
 //!
+//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
+//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
+//!
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
@@ -49,6 +52,9 @@
 //! - The received tag does not match the calculated tag when  calling [`open()`].
 //! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
 //! - Converting `usize` to `u64` would be a lossy conversion.
+//! - `plaintext.len() >` [`P_MAX`]
+//! - `ad.len() >` [`A_MAX`]
+//! - `ciphertext_with_tag.len() >` [`C_MAX`]
 //!
 //! # Panics:
 //! A panic will occur if:
@@ -100,6 +106,9 @@
 //! [`open()`]: chacha20poly1305::open
 //! [RFC]: https://tools.ietf.org/html/rfc8439#section-3
 //! [libsodium docs]: https://download.libsodium.org/doc/secret-key_cryptography/aead#additional-data
+//! [`P_MAX`]: chacha20poly1305::P_MAX
+//! [`A_MAX`]: chacha20poly1305::A_MAX
+//! [`C_MAX`]: chacha20poly1305::C_MAX
 
 pub use crate::hazardous::stream::chacha20::{Nonce, SecretKey};
 use crate::{
@@ -118,6 +127,15 @@ const ENC_CTR: u32 = 1;
 
 /// The initial counter used for Poly1305 key generation.
 const AUTH_CTR: u32 = 0;
+
+/// The maximum size of the plaintext (see [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439#section-2.8)).
+pub const P_MAX: u64 = (u32::MAX as u64) * 64;
+
+/// The maximum size of the ciphertext (see [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439#section-2.8)).
+pub const C_MAX: u64 = P_MAX + (POLY1305_OUTSIZE as u64);
+
+/// The maximum size of the associated data (see [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439#section-2.8)).
+pub const A_MAX: u64 = u64::MAX;
 
 /// Poly1305 key generation using IETF ChaCha20.
 pub(crate) fn poly1305_key_gen(
@@ -157,6 +175,15 @@ pub fn seal(
     ad: Option<&[u8]>,
     dst_out: &mut [u8],
 ) -> Result<(), UnknownCryptoError> {
+    if u64::try_from(plaintext.len()).map_err(|_| UnknownCryptoError)? > P_MAX {
+        return Err(UnknownCryptoError);
+    }
+
+    let ad = ad.unwrap_or(&[0u8; 0]);
+    if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
+        return Err(UnknownCryptoError);
+    }
+
     match plaintext.len().checked_add(POLY1305_OUTSIZE) {
         Some(out_min_len) => {
             if dst_out.len() < out_min_len {
@@ -171,7 +198,6 @@ pub fn seal(
     let mut tmp = Zeroizing::new([0u8; CHACHA_BLOCKSIZE]);
 
     let mut auth_ctx = Poly1305::new(&poly1305_key_gen(&mut stream, &mut tmp));
-    let ad = ad.unwrap_or(&[0u8; 0]);
     let ad_len = ad.len();
     let ct_len = plaintext.len();
 
@@ -241,6 +267,13 @@ pub fn open(
     ad: Option<&[u8]>,
     dst_out: &mut [u8],
 ) -> Result<(), UnknownCryptoError> {
+    if u64::try_from(ciphertext_with_tag.len()).map_err(|_| UnknownCryptoError)? > C_MAX {
+        return Err(UnknownCryptoError);
+    }
+    let ad = ad.unwrap_or(&[0u8; 0]);
+    if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
+        return Err(UnknownCryptoError);
+    }
     if ciphertext_with_tag.len() < POLY1305_OUTSIZE {
         return Err(UnknownCryptoError);
     }
@@ -254,7 +287,6 @@ pub fn open(
     let mut auth_ctx = Poly1305::new(&poly1305_key_gen(&mut dec_ctx, &mut tmp));
 
     let ciphertext_len = ciphertext_with_tag.len() - POLY1305_OUTSIZE;
-    let ad = ad.unwrap_or(&[0u8; 0]);
     process_authentication(&mut auth_ctx, ad, &ciphertext_with_tag[..ciphertext_len])?;
     util::secure_cmp(
         auth_ctx.finalize()?.unprotected_as_bytes(),

--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -34,6 +34,13 @@
 //! - `tag`: Indicates the type of message. The `tag` is a part of the output when encrypting. It
 //!   is encrypted and authenticated.
 //!
+//! `ad`: "A typical use for these data is to authenticate version numbers,
+//! timestamps or monotonically increasing counters in order to discard previous
+//! messages and prevent replay attacks." See [libsodium docs] for more information.
+//!
+//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
+//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
+//!
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` + [`ABYTES`] when calling [`seal_chunk()`].

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -34,6 +34,9 @@
 //! timestamps or monotonically increasing counters in order to discard previous
 //! messages and prevent replay attacks." See [libsodium docs] for more information.
 //!
+//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
+//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
+//!
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
@@ -43,6 +46,9 @@
 //! - The received tag does not match the calculated tag when  calling [`open()`].
 //! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
 //! - Converting `usize` to `u64` would be a lossy conversion.
+//! - `plaintext.len() >` [`chacha20poly1305::P_MAX`]
+//! - `ad.len() >` [`chacha20poly1305::A_MAX`]
+//! - `ciphertext_with_tag.len() >` [`chacha20poly1305::C_MAX`]
 //!
 //! # Panics:
 //! A panic will occur if:

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -409,6 +409,7 @@ pub(super) fn hchacha20(
 mod public {
     use super::*;
 
+    #[cfg(feature = "safe_api")]
     #[test]
     // See https://github.com/orion-rs/orion/issues/308
     fn test_plaintext_left_in_dst_out() {

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -409,6 +409,21 @@ pub(super) fn hchacha20(
 mod public {
     use super::*;
 
+    #[test]
+    // See https://github.com/orion-rs/orion/issues/308
+    fn test_plaintext_left_in_dst_out() {
+        let k = SecretKey::generate();
+        let n = Nonce::from_slice(&[0u8; 12]).unwrap();
+        let ic: u32 = u32::MAX - 1;
+
+        let text = [b'x'; 128 + 4];
+        let mut dst_out = [0u8; 128 + 4];
+
+        let err = encrypt(&k, &n, ic, &text, &mut dst_out).unwrap_err();
+
+        assert_ne!(&[b'x'; 4], &dst_out[dst_out.len() - 4..]);
+    }
+
     #[cfg(feature = "safe_api")]
     mod test_encrypt_decrypt {
         use super::*;

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -36,6 +36,9 @@
 //! because such a truncation may repeat after a short time." See [RFC]
 //! for more information.
 //!
+//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
+//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
+//!
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -419,7 +419,7 @@ mod public {
         let text = [b'x'; 128 + 4];
         let mut dst_out = [0u8; 128 + 4];
 
-        let err = encrypt(&k, &n, ic, &text, &mut dst_out).unwrap_err();
+        let _err = encrypt(&k, &n, ic, &text, &mut dst_out).unwrap_err();
 
         assert_ne!(&[b'x'; 4], &dst_out[dst_out.len() - 4..]);
     }

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -29,6 +29,9 @@
 //! - `dst_out`: Destination array that will hold the ciphertext/plaintext after
 //!   encryption/decryption.
 //!
+//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
+//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
+//!
 //! # Errors:
 //! An error will be returned if:
 //! - The length of `dst_out` is less than `plaintext` or `ciphertext`.


### PR DESCRIPTION
closes #308