### PR TITLE
Remove `html_root_url`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orion"
-version = "0.17.3" # Update html_root_url in lib.rs along with this.
+version = "0.17.3"
 authors = ["brycx <brycx@protonmail.com>"]
 description = "Usable, easy and safe pure-Rust crypto"
 keywords = [ "cryptography", "crypto", "aead", "hash", "mac" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@
     unused_qualifications,
     overflowing_literals
 )]
-#![doc(html_root_url = "https://docs.rs/orion/0.17.3")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(test)]


### PR DESCRIPTION
This is no longer recommended: https://github.com/rust-lang/api-guidelines/pull/230