### PR TITLE
Update `criterion` to `0.5.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.59.0 # MSRV
+          - 1.64.0 # MSRV
         os: 
           - ubuntu-latest
           - macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ __Changelog:__
 - Add `experimental` crate feature.
 - Add support for fully-committing AEAD variants based on CTX ([#324](https://github.com/orion-rs/orion/pull/324)).
 - Add support for SHA3 ([#327](https://github.com/orion-rs/orion/pull/327)).
+- Bump MSRV to `1.64`.
 
 ### 0.17.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1.0.41"
 serde = { version = "1.0", features = ["derive"] }
 quickcheck = "1"
 quickcheck_macros = "1"
-criterion = "0.4.0"
+criterion = "0.5.0"
 
 [[bench]]
 name = "bench"

--- a/deny.toml
+++ b/deny.toml
@@ -11,14 +11,7 @@ yanked = "deny"
 notice = "deny"
 unsound = "deny"
 vulnerability = "deny"
-ignore = [
-    # serde_cbor is unmaintained, used in criterion.
-    # See https://github.com/bheisler/criterion.rs/issues/534
-    "RUSTSEC-2021-0127",
-    # atty has unaligned read, used in criterion.
-    # See https://github.com/bheisler/criterion.rs/issues/629
-    "RUSTSEC-2021-0145",
-]
+ignore = []
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
- Bumps MSRV to `1.64`
- Removes the need to ignore two RUSTSEC advisories for unmaintained crate that have been replaced since

closes #306 