### PR TITLE
Update `fiat-crypto` to `0.2.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ __Date:__ TBD.
 
 __Changelog:__
 - Bump MSRV to `1.70.0`.
+- Bump `fiat-crypto` to `0.2.1`.
 
 ### 0.17.5
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 [dependencies]
 subtle = { version = "^2.2.2", default-features = false }
 zeroize = { version = "1.1.0", default-features = false }
-fiat-crypto = {version = "0.1.11", default-features = false}
+fiat-crypto = {version = "0.2.1", default-features = false}
 getrandom = { version = "0.2.0", optional = true }
 ct-codecs = { version = "1.1.1", optional = true }
 


### PR DESCRIPTION
The new release includes struct-based newtypes so this had to be adjusted for in Poly1305 and X25519.

Seems the `mips64-unknown-linux-gnuabi64` has somewhat been silently downgraded in target support with Rust `1.72` (https://github.com/rust-lang/rust/issues/115218). Maybe we can find a replacement?