### PR TITLE
Bump `cargo-deny` to `2.0.3`

### DIFF
--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -1,7 +1,6 @@
 name: cargo deny (licenses, advisories, sources)
 permissions:
   contents: read
-  issues: write
 
 on:
   push:

--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@f87fcad0e65efa7cbdec993036c394fa9be14262
+      - uses: EmbarkStudios/cargo-deny-action@2d8c9929d8f9f42bedba73f1287cb0b479f07acb
         with:
           command: check ${{ matrix.checks }}

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -20,8 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-///
-/// Trait implementation macros
+// Trait implementation macros
 
 #[cfg(feature = "safe_api")]
 /// Macro that implements the `Default` trait using a CSPRNG.
@@ -174,8 +173,7 @@ macro_rules! impl_try_from_trait (($name:ident) => (
     }
 ));
 
-///
-/// Function implementation macros
+// Function implementation macros
 
 /// Macro to implement a `from_slice()` function. Returns `UnknownCryptoError`
 /// if the slice length is not accepted.
@@ -463,8 +461,7 @@ macro_rules! test_generate_variable (($name:ident) => (
     }
 ));
 
-///
-/// Newtype implementation macros
+// Newtype implementation macros
 
 /// Macro to construct a type containing sensitive data, using a fixed-size
 /// array.


### PR DESCRIPTION
closes #415 