### PR TITLE
chore: fixed dead link in `tests/mac/other_poly1305.rs`

### DIFF
--- a/tests/mac/other_poly1305.rs
+++ b/tests/mac/other_poly1305.rs
@@ -21,7 +21,7 @@ fn libsodium_all_max_key() {
     poly1305_test_runner(&key, &input, &tag);
 }
 
-// https://github.com/LoupVaillant/Monocypher/blob/master/tests/vectors/poly1305
+// https://github.com/LoupVaillant/Monocypher/blob/master/tests/gen/vectors/poly1305
 
 #[test]
 fn monocypher_test_1() {


### PR DESCRIPTION
Hi! I fixed a broken link to test vectors in `tests/mac/other_poly1305.rs`. The previous link pointed to an outdated location in the Monocypher repository.