### PR TITLE
mlkem: Cache hash of encapsulation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 **Changelog:**
 - Add `encap_deterministic()` and `auth_encap_deterministic()` to `DhKem` in `hazardous::kem::x25519_hkdf_sha256::DhKem` [#458](https://github.com/orion-rs/orion/pull/458).
-- Make `hazardous::kem::x25519_hkdf_sha256::DhKem` available in `[no_std]` context [#458](https://github.com/orion-rs/orion/pull/458).
+- Make `hazardous::kem::x25519_hkdf_sha256::DhKem` available in `#![no_std]` context [#458](https://github.com/orion-rs/orion/pull/458).
 - Add support for HPKE (RFC 9180) [#458](https://github.com/orion-rs/orion/pull/458).
 - Switch to source-based code coverage [#462](https://github.com/orion-rs/orion/pull/462).
+- ML-KEM (internal): Cache hash of encapsulation key to save computation on multiple `encap()` operations [#464](https://github.com/orion-rs/orion/pull/464).
+- ML-KEM (internal): Cache encapsulation key within decapsulation key, to avoid re-computation after generation og decapsulation key [#447](https://github.com/orion-rs/orion/pull/447).
 
 ### 0.17.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add support for HPKE (RFC 9180) [#458](https://github.com/orion-rs/orion/pull/458).
 - Switch to source-based code coverage [#462](https://github.com/orion-rs/orion/pull/462).
 - ML-KEM (internal): Cache hash of encapsulation key to save computation on multiple `encap()` operations [#464](https://github.com/orion-rs/orion/pull/464).
-- ML-KEM (internal): Cache encapsulation key within decapsulation key, to avoid re-computation after generation og decapsulation key [#447](https://github.com/orion-rs/orion/pull/447).
+- ML-KEM (internal): Cache encapsulation key within decapsulation key, to avoid re-computation after generation of decapsulation key [#447](https://github.com/orion-rs/orion/pull/447).
 
 ### 0.17.9
 

--- a/src/hazardous/kem/ml_kem/internal/mod.rs
+++ b/src/hazardous/kem/ml_kem/internal/mod.rs
@@ -928,6 +928,20 @@ mod tests {
     use crate::hazardous::kem::ml_kem::mlkem768::KeyPair as MlKem768KeyPair;
 
     #[test]
+    fn test_keypair_dk_ek_match_internal() {
+        let seed = Seed::from_slice(&[128u8; 64]).unwrap();
+
+        let kp = MlKem512KeyPair::try_from(&seed).unwrap();
+        assert_eq!(kp.public().value, kp.private().value.ek);
+
+        let kp = MlKem768KeyPair::try_from(&seed).unwrap();
+        assert_eq!(kp.public().value, kp.private().value.ek);
+
+        let kp = MlKem1024KeyPair::try_from(&seed).unwrap();
+        assert_eq!(kp.public().value, kp.private().value.ek);
+    }
+
+    #[test]
     #[cfg(feature = "safe_api")]
     fn test_seed_and_dk_mismatch() {
         let seed = Seed::from_slice(&[128u8; 64]).unwrap();


### PR DESCRIPTION
With this we avoid re-computing for the hash for multiple `encap()` calls.