### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/src/hazardous/hash/sha3/mod.rs
+++ b/src/hazardous/hash/sha3/mod.rs
@@ -581,7 +581,7 @@ pub(crate) struct Shake<const RATE: usize> {
     //
     // A new tracker is `self.to_squeeze` that indicates how many bytes
     // are left to be squeezed out of the sponge. This is relevant when calling
-    // squeeze() multiple times, requesting data amounts that aren't a mulitple
+    // squeeze() multiple times, requesting data amounts that aren't a multiple
     // of the `RATE`. As soon as `RATE` amount of bytes have been squeezed(),
     // we have to permute the internal state, before we can output more bytes
     // `self.to_squeeze() == RATE` indicates we need to permute again...

--- a/src/hazardous/kem/ml_kem/internal/mod.rs
+++ b/src/hazardous/kem/ml_kem/internal/mod.rs
@@ -111,7 +111,7 @@ pub(crate) trait PkeParameters {
     fn encapsulation_key_check(ek: &[u8]) -> Result<(), UnknownCryptoError> {
         debug_assert_eq!(Self::EK_SIZE, (ENCODE_SIZE_POLY * Self::K) + 32);
         // Encapsulation key check, Check 1.
-        // This should never actuallly happen, since the Encapsulation key newtype has already
+        // This should never actually happen, since the Encapsulation key newtype has already
         // had a check on length.
         if ek.len() != Self::EK_SIZE {
             return Err(UnknownCryptoError);
@@ -140,7 +140,7 @@ pub(crate) trait PkeParameters {
     /// automatically a part of that newtype.
     fn decapsulation_key_check(dk: &[u8]) -> Result<(), UnknownCryptoError> {
         // Decapsulation input check, Check 2.
-        // This should never actuallly happen, since the Decapsulation key newtype has already
+        // This should never actually happen, since the Decapsulation key newtype has already
         // had a check on length.
         if dk.len() != Self::DK_SIZE {
             return Err(UnknownCryptoError);

--- a/src/high_level/kex.rs
+++ b/src/high_level/kex.rs
@@ -261,7 +261,7 @@ mod public {
             .is_err());
     }
 
-    // The following are tests generated with sodiumoxide to test basic compatability with libsodium API.
+    // The following are tests generated with sodiumoxide to test basic compatibility with libsodium API.
     #[test]
     fn libsodium_compat_test_1() {
         let client_pk = "299283d8713b7d430376cb257e13cd5ad1a6e5ebe6135417f4bb3b45bf42f31a";


### PR DESCRIPTION


**Description:**

This pull request addresses several typographical errors in the documentation comments across multiple files. The changes include:

1. **File:** `src/hazardous/hash/sha3/mod.rs`
   - Corrected the spelling of "multiple" in a comment.

2. **File:** `src/hazardous/kem/ml_kem/internal/mod.rs`
   - Fixed the spelling of "actually" in comments for encapsulation and decapsulation key checks.

3. **File:** `src/high_level/kex.rs`
   - Corrected the spelling of "compatibility" in a comment related to test generation.

These changes improve the readability and professionalism of the codebase documentation. No functional code changes have been made.
