### PR TITLE
Fix Typographical Errors in Comments

### DIFF
--- a/src/hazardous/kem/ml_kem/internal/mod.rs
+++ b/src/hazardous/kem/ml_kem/internal/mod.rs
@@ -844,7 +844,7 @@ impl<Pke: PkeParameters> KeyPairInternal<Pke> {
             _phantom: PhantomData,
         };
         // Cache the ek separately as well for re-use in MLEKM.decap_internal().
-        // `ek` is used directly whithin dk during keygen.
+        // `ek` is used directly within dk during keygen.
         let mut decap_key = DecapKey::<K, ENCODED_SIZE_EK, ENCODED_SIZE_DK, Pke> {
             bytes: [0u8; ENCODED_SIZE_DK],
             s_hat: [RingElementNTT::zero(); K],

--- a/src/test_framework/hpke_interface.rs
+++ b/src/test_framework/hpke_interface.rs
@@ -786,7 +786,7 @@ impl<T: TestableHpke> HpkeTester<T> {
         let mut dst = [0u8; 24 - 16];
         assert!(recipient.open(&out, &[], &mut dst).is_err());
 
-        // Recevier uses bad Sender pub
+        // Receiver uses bad Sender pub
         let mut sender = T::setup_fresh_sender(
             &recipient_pub,
             &valid_info,


### PR DESCRIPTION


**Description:** 
This pull request corrects typographical errors in comments within the codebase. Specifically, it changes "withink" to "within" in `mod.rs` and corrects the capitalization in `hpke_interface.rs`. These changes improve the readability and professionalism of the code comments.
