### PR TITLE
make `alloc` and `serde` compilation more robust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test debug-mode, no-default + alloc feature
         run: cargo test --no-default-features --features alloc --tests
 
+      - name: Test debug-mode, no-default + serde feature (enables alloc)
+        run: cargo test --no-default-features --features serde --tests
+
       - name: Test release-mode, default features
         run: cargo test --release
 
@@ -62,6 +65,9 @@ jobs:
 
       - name: Test release-mode, no-default + alloc feature
         run: cargo test --release --no-default-features --features alloc --tests
+
+      - name: Test release-mode, no-default + serde feature (enables alloc)
+        run: cargo test --release --no-default-features --features serde --tests
 
   sanitizers:
     name: Tests w. sanitizers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ features = ["alloc"]
 default = ["safe_api"]
 safe_api = ["getrandom", "ct-codecs"]
 alloc = []
+serde = ["dep:serde", "alloc"]
 experimental = []
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ MSRV may be changed at any point and will not be considered a SemVer breaking ch
 ### Crate Features
 
 - `default`/`safe_api`: All functionality, requires `std`.
-- `serde`: Requires either `alloc` or `default`/`safe_api`.
+- `serde`: Automatically enables the `alloc` feature.
 - `alloc`: Argon2i in `hazardous` when `default`/`safe_api` is not available.
 - `no_std`: Implicit feature that represents no heap allocations. Enabled by disabling default features and not selecting any additional features.
 - `experimental`: These APIs may contain breaking changes in any non SemVer-breaking crate releases.

--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -451,7 +451,7 @@ pub fn derive_key(
     // Divide by 4 (SEGMENTS_PER_LANE)
     let segment_length = n_blocks >> 2;
 
-    let mut blocks = vec![[0u64; 128]; n_blocks as usize];
+    let mut blocks = alloc::vec![[0u64; 128]; n_blocks as usize];
 
     // Fill first two blocks
     let mut h0 = initial_hash(
@@ -571,12 +571,12 @@ mod public {
             } else {
                 kib
             };
-            let salt = if s.len() < 8 { vec![37u8; 8] } else { s };
+            let salt = if s.len() < 8 { alloc::vec![37u8; 8] } else { s };
 
             let mut dst_out = if !(4..=512).contains(&hlen) {
-                vec![0u8; 32]
+                alloc::vec![0u8; 32]
             } else {
-                vec![0u8; hlen as usize]
+                alloc::vec![0u8; hlen as usize]
             };
 
             let mut dst_out_verify = dst_out.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,9 @@ extern crate quickcheck;
 extern crate quickcheck_macros;
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(feature = "alloc", macro_use)]
 extern crate alloc;
+#[cfg(all(not(feature = "alloc"), feature = "safe_api"))]
+extern crate std as alloc;
 
 #[macro_use]
 mod typedefs;

--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -114,8 +114,8 @@ macro_rules! impl_serde_traits (($name:ident, $bytes_function:ident) => (
         where
             D: serde::de::Deserializer<'de>,
         {
-            let bytes = Vec::<u8>::deserialize(deserializer)?;
-            std::convert::TryFrom::try_from(bytes.as_slice()).map_err(serde::de::Error::custom)
+            let bytes = alloc::vec::Vec::<u8>::deserialize(deserializer)?;
+            core::convert::TryFrom::try_from(bytes.as_slice()).map_err(serde::de::Error::custom)
         }
     }
 ));
@@ -214,7 +214,7 @@ macro_rules! func_from_slice_variable_size (($name:ident) => (
             return Err(UnknownCryptoError);
         }
 
-        Ok($name { value: Vec::from(slice), original_length: slice.len() })
+        Ok($name { value: alloc::vec::Vec::from(slice), original_length: slice.len() })
     }
 ));
 
@@ -917,7 +917,7 @@ macro_rules! construct_secret_key_variable_size {
         /// # Ok::<(), orion::errors::UnknownCryptoError>(())
         /// ```
         pub struct $name {
-            pub(crate) value: Vec<u8>,
+            pub(crate) value: alloc::vec::Vec<u8>,
             original_length: usize,
         }
 
@@ -957,7 +957,7 @@ macro_rules! construct_salt_variable_size {
         $(#[$meta])*
         ///
         pub struct $name {
-            value: Vec<u8>,
+            value: alloc::vec::Vec<u8>,
             original_length: usize,
         }
 


### PR DESCRIPTION
This fixes compilation that didn't succeed before like this: 
```sh
cargo b --features serde,alloc --no-default-features
```

And by auto-enabling `alloc` with serde it now works also like this:
```sh
cargo b --features serde --no-default-features
```

And it keeps working as before, like this:
```sh
cargo b
cargo b --features serde
cargo b --no-default-features
```
