### PR TITLE
Added unit test for edge cases on x25519 keys

### DIFF
--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -891,23 +891,31 @@ mod public {
     #[test]
     fn test_privatekey_edge_cases() {
         // all zeros - clamped in RFC 7748, should be accepted
-        assert!(PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(), "all-zero key");
-    
+        assert!(
+            PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(),
+            "all-zero key"
+        );
+
         // all ones - clamped, should be accepted
-        assert!(PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(), "all-ones key");
-    
+        assert!(
+            PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(),
+            "all-ones key"
+        );
+
         // alternating bits - arbitrary pattern, should be accepted
-        assert!(PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(), "alternating-bits key");
-    
+        assert!(
+            PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(),
+            "alternating-bits key"
+        );
+
         // only first byte set
         let mut first = [0u8; PRIVATE_KEY_SIZE];
         first[0] = 1;
         assert!(PrivateKey::from_slice(&first).is_ok(), "first-byte-set key");
-    
+
         // only last byte set
         let mut last = [0u8; PRIVATE_KEY_SIZE];
         last[PRIVATE_KEY_SIZE - 1] = 1;
         assert!(PrivateKey::from_slice(&last).is_ok(), "last-byte-set key");
     }
-
 }

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -887,4 +887,27 @@ mod public {
             shared.value.as_ref()
         );
     }
+
+    #[test]
+    fn test_privatekey_edge_cases() {
+        // all zeros - clamped in RFC 7748, should be accepted
+        assert!(PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(), "all-zero key");
+    
+        // all ones - clamped, should be accepted
+        assert!(PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(), "all-ones key");
+    
+        // alternating bits - arbitrary pattern, should be accepted
+        assert!(PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(), "alternating-bits key");
+    
+        // only first byte set
+        let mut first = [0u8; PRIVATE_KEY_SIZE];
+        first[0] = 1;
+        assert!(PrivateKey::from_slice(&first).is_ok(), "first-byte-set key");
+    
+        // only last byte set
+        let mut last = [0u8; PRIVATE_KEY_SIZE];
+        last[PRIVATE_KEY_SIZE - 1] = 1;
+        assert!(PrivateKey::from_slice(&last).is_ok(), "last-byte-set key");
+    }
+
 }

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -890,32 +890,18 @@ mod public {
 
     #[test]
     fn test_privatekey_edge_cases() {
-        // all zeros - clamped in RFC 7748, should be accepted
-        assert!(
-            PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(),
-            "all-zero key"
-        );
+        assert!(PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok());
 
-        // all ones - clamped, should be accepted
-        assert!(
-            PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(),
-            "all-ones key"
-        );
+        assert!(PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok());
 
-        // alternating bits - arbitrary pattern, should be accepted
-        assert!(
-            PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(),
-            "alternating-bits key"
-        );
+        assert!(PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok());
 
-        // only first byte set
         let mut first = [0u8; PRIVATE_KEY_SIZE];
         first[0] = 1;
-        assert!(PrivateKey::from_slice(&first).is_ok(), "first-byte-set key");
+        assert!(PrivateKey::from_slice(&first).is_ok());
 
-        // only last byte set
         let mut last = [0u8; PRIVATE_KEY_SIZE];
         last[PRIVATE_KEY_SIZE - 1] = 1;
-        assert!(PrivateKey::from_slice(&last).is_ok(), "last-byte-set key");
+        assert!(PrivateKey::from_slice(&last).is_ok());
     }
 }


### PR DESCRIPTION
This introduces a unit test for handling edge cases related to private keys in the x25519 algorithm. The test checks several edge cases for private keys, ensuring the implementation correctly handles these unusual but valid cases.

Test Scenarios Added:
- All Zeros: A private key with all zero values, which is clamped in RFC 7748, should be accepted.
- All Ones: A private key with all ones, which is clamped, should be accepted.
- Alternating Bits: A private key with an alternating bit pattern, which is an arbitrary pattern, should be accepted.
- First Byte Set: A private key where only the first byte is set, should be accepted.
- Last Byte Set: A private key where only the last byte is set, should be accepted.