### PR TITLE
Unit test verifying that the most significant bit of the last byte in an x25519 public key is correctly masked

### DIFF
--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -891,23 +891,31 @@ mod public {
     #[test]
     fn test_privatekey_edge_cases() {
         // all zeros - clamped in RFC 7748, should be accepted
-        assert!(PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(), "all-zero key");
-    
+        assert!(
+            PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(),
+            "all-zero key"
+        );
+
         // all ones - clamped, should be accepted
-        assert!(PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(), "all-ones key");
-    
+        assert!(
+            PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(),
+            "all-ones key"
+        );
+
         // alternating bits - arbitrary pattern, should be accepted
-        assert!(PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(), "alternating-bits key");
-    
+        assert!(
+            PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(),
+            "alternating-bits key"
+        );
+
         // only first byte set
         let mut first = [0u8; PRIVATE_KEY_SIZE];
         first[0] = 1;
         assert!(PrivateKey::from_slice(&first).is_ok(), "first-byte-set key");
-    
+
         // only last byte set
         let mut last = [0u8; PRIVATE_KEY_SIZE];
         last[PRIVATE_KEY_SIZE - 1] = 1;
         assert!(PrivateKey::from_slice(&last).is_ok(), "last-byte-set key");
     }
-
 }

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -904,4 +904,20 @@ mod public {
         last[PRIVATE_KEY_SIZE - 1] = 1;
         assert!(PrivateKey::from_slice(&last).is_ok());
     }
+
+    #[test]
+    // Tests masking the most significant bit of the final byte when constructing a public key - RFC 7784 Section 5
+    fn test_masking_msb_final_byte_public_key() {
+        let u = [0xffu8; 32];
+
+        let mut msb_zero = u;
+        msb_zero[31] &= 0x7f;
+        let mut msb_one = u;
+        msb_one[31] |= 0x80;
+
+        let pk_zero = PublicKey::from_slice(&msb_zero).unwrap();
+        let pk_one = PublicKey::from_slice(&msb_one).unwrap();
+
+        assert_eq!(pk_zero.to_bytes(), pk_one.to_bytes());
+    }
 }

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -887,4 +887,27 @@ mod public {
             shared.value.as_ref()
         );
     }
+
+    #[test]
+    fn test_privatekey_edge_cases() {
+        // all zeros - clamped in RFC 7748, should be accepted
+        assert!(PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(), "all-zero key");
+    
+        // all ones - clamped, should be accepted
+        assert!(PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(), "all-ones key");
+    
+        // alternating bits - arbitrary pattern, should be accepted
+        assert!(PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(), "alternating-bits key");
+    
+        // only first byte set
+        let mut first = [0u8; PRIVATE_KEY_SIZE];
+        first[0] = 1;
+        assert!(PrivateKey::from_slice(&first).is_ok(), "first-byte-set key");
+    
+        // only last byte set
+        let mut last = [0u8; PRIVATE_KEY_SIZE];
+        last[PRIVATE_KEY_SIZE - 1] = 1;
+        assert!(PrivateKey::from_slice(&last).is_ok(), "last-byte-set key");
+    }
+
 }

--- a/src/hazardous/ecc/x25519.rs
+++ b/src/hazardous/ecc/x25519.rs
@@ -890,32 +890,18 @@ mod public {
 
     #[test]
     fn test_privatekey_edge_cases() {
-        // all zeros - clamped in RFC 7748, should be accepted
-        assert!(
-            PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok(),
-            "all-zero key"
-        );
+        assert!(PrivateKey::from_slice(&[0u8; PRIVATE_KEY_SIZE]).is_ok());
 
-        // all ones - clamped, should be accepted
-        assert!(
-            PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok(),
-            "all-ones key"
-        );
+        assert!(PrivateKey::from_slice(&[0xffu8; PRIVATE_KEY_SIZE]).is_ok());
 
-        // alternating bits - arbitrary pattern, should be accepted
-        assert!(
-            PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok(),
-            "alternating-bits key"
-        );
+        assert!(PrivateKey::from_slice(&[0b10101010u8; PRIVATE_KEY_SIZE]).is_ok());
 
-        // only first byte set
         let mut first = [0u8; PRIVATE_KEY_SIZE];
         first[0] = 1;
-        assert!(PrivateKey::from_slice(&first).is_ok(), "first-byte-set key");
+        assert!(PrivateKey::from_slice(&first).is_ok());
 
-        // only last byte set
         let mut last = [0u8; PRIVATE_KEY_SIZE];
         last[PRIVATE_KEY_SIZE - 1] = 1;
-        assert!(PrivateKey::from_slice(&last).is_ok(), "last-byte-set key");
+        assert!(PrivateKey::from_slice(&last).is_ok());
     }
 }


### PR DESCRIPTION
This introduces a unit test to verify the proper handling of the most significant bit (MSB) masking in public keys for the x25519 algorithm. The test checks that the `PublicKey::from_slice` function correctly masks the MSB of the final byte of the public key when it's constructed.

Test Scenarios Added:
- MSB Set in Input: A public key where the most significant bit (MSB) of the last byte is set. The test ensures the MSB is cleared during the construction of the public key.
- Correctness of Masking: Verifies that the final byte after masking matches the original byte with the MSB cleared.

This ensures that public keys conform to the RFC 7748 §5, which states that "implementations of X25519 MUST mask the most significant bit in the final byte".
