### PR TITLE
polishing docs: error fixes for clarity

### DIFF
--- a/src/hazardous/kdf/argon2i.rs
+++ b/src/hazardous/kdf/argon2i.rs
@@ -341,7 +341,7 @@ impl Gidx {
         self.next_addresses(tmp_block);
 
         // The existing values in self.addresses are not read
-        // when generating a new address block. Therefor we
+        // when generating a new address block. Therefore we
         // do not have to zero it out.
     }
 

--- a/tests/cae/mod.rs
+++ b/tests/cae/mod.rs
@@ -27,7 +27,7 @@ fn wycheproof_runner(path: &str) {
             match test.result.as_str() {
                 "valid" => true,
                 // The only thing we want to test for CTX is that it still produces
-                // ciphertexts matching the underlying AE. Therefor, invalid test cases
+                // ciphertexts matching the underlying AE. Therefore, invalid test cases
                 // are of no interest here.
                 "invalid" => continue,
                 _ => panic!("Unexpected test outcome for Wycheproof test"),


### PR DESCRIPTION
Spotted and fixed a few wording hiccups:
`Therefor` - `Therefore`