### PR TITLE
fix: improve error handling in secure_rand_bytes function

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -78,7 +78,7 @@ pub fn secure_rand_bytes(dst: &mut [u8]) -> Result<(), errors::UnknownCryptoErro
         return Err(errors::UnknownCryptoError);
     }
 
-    getrandom::fill(dst).unwrap();
+    getrandom::fill(dst).map_err(|_| errors::UnknownCryptoError)?;
 
     Ok(())
 }


### PR DESCRIPTION
Replace unwrap() with map_err() to handle errors from getrandom::fill gracefully, returning UnknownCryptoError instead of panicking on failure.