### PR TITLE
chacha20poly1305: add XChaCha20-Poly1305 support

### DIFF
--- a/tests/aead/other_xchacha20_poly1305.rs
+++ b/tests/aead/other_xchacha20_poly1305.rs
@@ -80,7 +80,7 @@ mod sodiumoxide_xchacha20_poly1305 {
     }
 }
 
-// Wireguard test vectors: https://git.zx2c4.com/wireguard-go/tree/xchacha20poly1305/xchacha20_test.go
+// Wireguard test vectors: https://github.com/golang/crypto/blob/master/chacha20poly1305/xchacha20poly1305.go
 // Pulled the 26th November 2018.
 #[cfg(test)]
 mod wireguard_xchacha20_poly1305 {


### PR DESCRIPTION
Adds an implementation of the XChaCha20-Poly1305 AEAD that uses a 24-byte nonce instead of the standard 12-byte one. This makes it possible to safely generate random nonces without risk of collisions, which is particularly important for systems where nonce uniqueness cannot be ensured by other means

