### PR TITLE
fix: correct typo in conditional_sub_u32 comment

### DIFF
--- a/src/hazardous/kem/ml_kem/internal/fe.rs
+++ b/src/hazardous/kem/ml_kem/internal/fe.rs
@@ -55,7 +55,7 @@ fn conditional_sub_u32(a: u32) -> u32 {
     let t: u32 = a.overflowing_sub(KYBER_Q).0;
 
     // Check if a >= mod (if t is non-negative)
-    // If a >= mod, mask will be 0xFFFFFFF, otherwise 0
+    // If a >= mod, mask will be 0xFFFFFFFF, otherwise 0
     let mask: u32 = 0u32.overflowing_sub(t >> 31).0;
 
     // If mask is 0, return a (no subtraction), otherwise return t (a - mod)


### PR DESCRIPTION
Fix typo in comment where 0xFFFFFFF was incorrectly written instead of 0xFFFFFFFF

- Line 58: Changed 0xFFFFFFF to 0xFFFFFFFF in comment
- This aligns the comment with the actual 32-bit mask value used in the code
- The comment now correctly describes the 32-bit mask pattern