### PR TITLE
chore: fix broken link

### DIFF
--- a/tests/test_generation/pynacl_secretstream_test_vector.c
+++ b/tests/test_generation/pynacl_secretstream_test_vector.c
@@ -1,5 +1,5 @@
 /*
-    Taken from: https://pynacl.readthedocs.io/en/stable/vectors/secretstream_vectors/
+    Taken from: https://pynacl.readthedocs.io/en/latest/vectors/secretstream_vectors/
     26th October 2019.
 */
 


### PR DESCRIPTION
https://pynacl.readthedocs.io/en/stable/vectors/secretstream_vectors/ - old link
https://pynacl.readthedocs.io/en/latest/vectors/secretstream_vectors/ - actual link