### PR TITLE
fix(docs): correct typos and grammar in test framework comments

### DIFF
--- a/src/test_framework/kem_interface.rs
+++ b/src/test_framework/kem_interface.rs
@@ -96,7 +96,7 @@ where
         let k1_prime = T::decap(&dk1, &c1).unwrap();
         let k2_prime = T::decap(&dk1, &c2).unwrap();
         assert_ne!(k1_prime, k2_prime);
-        // Repeat decap() to ensure the's no bad internal state-management.
+        // Repeat decap() to ensure there's no bad internal state-management.
         assert_eq!(k1_prime, T::decap(&dk1, &c1).unwrap());
         assert_eq!(k2_prime, T::decap(&dk1, &c2).unwrap());
     }

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -65,7 +65,7 @@ pub fn StreamCipherTestRunner<Encryptor, Decryptor, Key, Nonce>(
 }
 
 #[cfg(feature = "safe_api")]
-/// Given a input length `a` find out how many times
+/// Given an input length `a` find out how many times
 /// the initial counter on encrypt()/decrypt() would
 /// increase.
 fn counter_increase_times(a: f32) -> u32 {
@@ -200,7 +200,7 @@ fn encrypt_decrypt_equals_expected<Encryptor, Decryptor, Key, Nonce>(
 }
 
 #[cfg(feature = "safe_api")]
-/// Test that a initial counter will not overflow the internal.
+/// Test that an initial counter will not overflow the internal.
 fn initial_counter_overflow_err<Encryptor, Decryptor, Key, Nonce>(
     encryptor: &Encryptor,
     decryptor: &Decryptor,


### PR DESCRIPTION
src/test_framework/kem_interface.rs: fixed contraction typo (the's → there's).

src/test_framework/streamcipher_interface.rs:

- corrected article usage (a input → an input).

- corrected article usage (a initial → an initial).