### PR TITLE
fix: correctly zeroize value field in Drop impl instead of iterator

### DIFF
--- a/src/typedefs.rs
+++ b/src/typedefs.rs
@@ -129,7 +129,7 @@ macro_rules! impl_drop_trait (($name:ident) => (
             #[cfg(feature = "zeroize")]
             {
               use zeroize::Zeroize;
-              self.value.iter_mut().zeroize();
+              self.value.zeroize();
             }
         }
     }


### PR DESCRIPTION
Calling .zeroize() on the iterator instead of self.value meant secret keys were never cleared from memory on drop