### PR TITLE
`v0.18.0`: Add (X)ChaCha20 structs and (X)ChaCha20Poly1305 structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,13 @@
 - [Breaking change] `orion::hazardous::kem::xwing::EncapsulationKey` now fails on `TryFrom<&[u8]>` if the ML-KEM-768 public-part does not pass the FIPS-203 keys checks.
 - [Breaking change] `orion::hazardous::kem::x25519_hkdf_sha256` uses as separate `PrivateKey` type to ensure RFC9180 `SerializePrivateKey()` and `DeserializePrivateKey()` clamping requirements are uphled.
 	- This was previously a part of `orion::hazardous::ecc::x25519::SecretKey` but has been moved to HPKE, since it is a HPKE-specific requirement.
-
+- [Breaking change] `orion::hazardous::stream`:
+	- [Breaking change]: Remove `chacha20::encrypt()`, `chacha20::decrypt()`, `xchacha20::encrypt()` and `xchacha20::decrypt()`.
+	- Add structs `ChaCha20` and `XChaCha20` that can be used for encryption/decryption and with a more stream-oriented API (including seeking ahead).
+- [Breaking change] `orion::hazardous::aead`:
+	- [Breaking change]: Remove `chacha20poly1305::seal()`, `chacha20poly1305::open()`, `xchacha20poly1305::seal()` `xchacha20poly1305::open()`.
+	- Add structs `ChaCha20Poly1305` and `XChaCha20Poly1305` that offer equivalent `open()` and `seal()` functions from versions prior to `0.18.0`.
+	- Add support for `seal_inplace()` and `open_inplace()` for `ChaCha20Poly1305` and `XChaCha20Poly1305`. These overwrite data directly instead of copying and allow handling the authentication tag separately.
 - MSRV bumped to `1.87`
 - Add constants for BLAKE2b: `BLAKE2B_MIN_OUTSIZE, BLAKE2B_MAX_OUTSIZE, BLAKE2B_MIN_KEYSIZE, BLAKE2B_MAX_KEYSIZE` making the conditions more discernable.
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -116,20 +116,17 @@ mod aead {
         let nonce = chacha20poly1305::Nonce::try_from(&[0u8; 12]).unwrap();
 
         for size in INPUT_SIZES.iter() {
-            let input = vec![0u8; *size];
-            let mut out = vec![0u8; input.len() + 16];
+            let mut bytes = vec![0u8; *size];
 
             group.throughput(Throughput::Bytes(*size as u64));
-            group.bench_with_input(
-                BenchmarkId::new("encrypt", *size),
-                &input,
-                |b, input_message| {
-                    b.iter(|| {
-                        chacha20poly1305::seal(&key, &nonce, &input_message, None, &mut out)
-                            .unwrap()
-                    })
-                },
-            );
+            group.bench_function(BenchmarkId::new("encrypt", *size), |b| {
+                b.iter(|| {
+                    let _tag = chacha20poly1305::ChaCha20Poly1305::seal_inplace(
+                        &key, &nonce, None, &mut bytes,
+                    )
+                    .unwrap();
+                })
+            });
         }
     }
 
@@ -139,20 +136,17 @@ mod aead {
         let nonce = xchacha20poly1305::Nonce::generate().unwrap();
 
         for size in INPUT_SIZES.iter() {
-            let input = vec![0u8; *size];
-            let mut out = vec![0u8; input.len() + 16];
+            let mut bytes = vec![0u8; *size];
 
             group.throughput(Throughput::Bytes(*size as u64));
-            group.bench_with_input(
-                BenchmarkId::new("encrypt", *size),
-                &input,
-                |b, input_message| {
-                    b.iter(|| {
-                        xchacha20poly1305::seal(&key, &nonce, &input_message, None, &mut out)
-                            .unwrap()
-                    })
-                },
-            );
+            group.bench_function(BenchmarkId::new("encrypt", *size), |b| {
+                b.iter(|| {
+                    let _tag = xchacha20poly1305::XChaCha20Poly1305::seal_inplace(
+                        &key, &nonce, None, &mut bytes,
+                    )
+                    .unwrap();
+                })
+            });
         }
     }
 
@@ -246,24 +240,24 @@ mod hash {
 }
 
 mod stream {
+    use orion::hazardous::stream::{chacha20::ChaCha20, xchacha20::XChaCha20};
+
     use super::*;
 
     pub fn bench_chacha20(c: &mut Criterion) {
         let mut group = c.benchmark_group("ChaCha20");
-        let key = chacha20poly1305::SecretKey::generate().unwrap();
-        let nonce = chacha20poly1305::Nonce::from([0u8; 12]);
+        let key = chacha20::SecretKey::generate().unwrap();
+        let nonce = chacha20::Nonce::from([0u8; 12]);
+        let ctx = ChaCha20::new(&key, &nonce);
 
         for size in INPUT_SIZES.iter() {
-            let input = vec![0u8; *size];
-            let mut out = vec![0u8; input.len()];
+            let mut out = vec![0u8; *size];
+            let mut wctx = ctx.clone();
 
             group.throughput(Throughput::Bytes(*size as u64));
-            group.bench_with_input(
+            group.bench_function(
                 BenchmarkId::new("xor-stream", *size),
-                &input,
-                |b, input_message| {
-                    b.iter(|| chacha20::encrypt(&key, &nonce, 0, &input_message, &mut out).unwrap())
-                },
+                |b: &mut Bencher<'_>| b.iter(|| wctx.xor_keystream_into(&mut out).unwrap()),
             );
         }
     }
@@ -272,20 +266,16 @@ mod stream {
         let mut group = c.benchmark_group("XChaCha20");
         let key = xchacha20::SecretKey::generate().unwrap();
         let nonce = xchacha20::Nonce::generate().unwrap();
+        let ctx = XChaCha20::new(&key, &nonce);
 
         for size in INPUT_SIZES.iter() {
-            let input = vec![0u8; *size];
-            let mut out = vec![0u8; input.len()];
+            let mut out = vec![0u8; *size];
+            let mut wctx = ctx.clone();
 
             group.throughput(Throughput::Bytes(*size as u64));
-            group.bench_with_input(
+            group.bench_function(
                 BenchmarkId::new("xor-stream", *size),
-                &input,
-                |b, input_message| {
-                    b.iter(|| {
-                        xchacha20::encrypt(&key, &nonce, 0, &input_message, &mut out).unwrap()
-                    })
-                },
+                |b: &mut Bencher<'_>| b.iter(|| wctx.xor_keystream_into(&mut out).unwrap()),
             );
         }
     }

--- a/src/generics/keytype.rs
+++ b/src/generics/keytype.rs
@@ -286,7 +286,7 @@ impl<T: TypeSpec> serde::Serialize for Public<T> {
     where
         S: serde::ser::Serializer,
     {
-        let bytes: &[u8] = &self.data.as_ref();
+        let bytes: &[u8] = self.data.as_ref();
         bytes.serialize(serializer)
     }
 }

--- a/src/hazardous/aead/chacha20poly1305.rs
+++ b/src/hazardous/aead/chacha20poly1305.rs
@@ -21,14 +21,16 @@
 // SOFTWARE.
 
 //! # Parameters:
-//! - `secret_key`: The secret key.
-//! - `nonce`: The nonce value.
+//! - `sk`: The secret key.
+//! - `n`: The nonce value.
 //! - `ad`: Additional data to authenticate (this is not encrypted and can be [`None`]).
 //! - `ciphertext_with_tag`: The encrypted data with the corresponding 16 byte
 //!   Poly1305 tag appended to it.
 //! - `plaintext`: The data to be encrypted.
 //! - `dst_out`: Destination array that will hold the
 //!   `ciphertext_with_tag`/`plaintext` after encryption/decryption.
+//! - `bytes`: Bytes that are either encrypted or decrypted.
+//! - `tag`: The Poly1305 tag used for authenticity verification when using [`ChaCha20Poly1305::open_inplace()`].
 //!
 //! `ad`: "A typical use for these data is to authenticate version numbers,
 //! timestamps or monotonically increasing counters in order to discard previous
@@ -45,20 +47,16 @@
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
+//! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`ChaCha20Poly1305::seal()`].
 //! - The length of `dst_out` is less than `ciphertext_with_tag` - [`POLY1305_OUTSIZE`] when
-//!   calling [`open()`].
+//!   calling [`ChaCha20Poly1305::open()`].
 //! - The length of `ciphertext_with_tag` is not at least [`POLY1305_OUTSIZE`].
-//! - The received tag does not match the calculated tag when  calling [`open()`].
-//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
-//! - Converting `usize` to `u64` would be a lossy conversion.
+//! - The received tag does not match the calculated tag when  calling [`ChaCha20Poly1305::open()`]/[`ChaCha20Poly1305::open_inplace()`].
+//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`ChaCha20Poly1305::seal()`].
+//! - Converting [`usize`] to [`u64`] would be a lossy conversion.
 //! - `plaintext.len() >` [`P_MAX`]
 //! - `ad.len() >` [`A_MAX`]
 //! - `ciphertext_with_tag.len() >` [`C_MAX`]
-//!
-//! # Panics:
-//! A panic will occur if:
-//! - More than `2^32-1 * 64` bytes of data are processed.
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
@@ -75,50 +73,59 @@
 //! # Example:
 //! ```rust
 //! # #[cfg(feature = "safe_api")] {
-//! use orion::hazardous::aead;
+//! use orion::hazardous::aead::chacha20poly1305::{SecretKey, Nonce, ChaCha20Poly1305};
 //!
-//! let secret_key = aead::chacha20poly1305::SecretKey::generate()?;
-//!
+//! let sk = SecretKey::generate()?;
 //! // WARNING: This nonce is only meant for demonstration and should not
 //! // be repeated. Please read the security section.
-//! let nonce = aead::chacha20poly1305::Nonce::from([0u8; 12]);
+//! let n = Nonce::from([0u8; 12]);
 //! let ad = "Additional data".as_bytes();
 //! let message = "Data to protect".as_bytes();
 //!
+//! // With output buffer:
+//!
 //! // Length of the above message is 15 and then we accommodate 16 for the Poly1305
 //! // tag.
-//!
 //! let mut dst_out_ct = [0u8; 15 + 16];
 //! let mut dst_out_pt = [0u8; 15];
 //! // Encrypt and place ciphertext + tag in dst_out_ct
-//! aead::chacha20poly1305::seal(&secret_key, &nonce, message, Some(&ad), &mut dst_out_ct)?;
+//! ChaCha20Poly1305::seal(&sk, &n, message, Some(&ad), &mut dst_out_ct)?;
 //! // Verify tag, if correct then decrypt and place message in dst_out_pt
-//! aead::chacha20poly1305::open(&secret_key, &nonce, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
-//!
+//! ChaCha20Poly1305::open(&sk, &n, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
 //! assert_eq!(dst_out_pt.as_ref(), message.as_ref());
+//!
+//! // In-place:
+//! let mut message: [u8; 15] = *b"Data to protect";
+//! let tag = ChaCha20Poly1305::seal_inplace(&sk, &n, Some(&ad), &mut message)?;
+//! assert_eq!(&dst_out_ct[..15], &message);
+//! ChaCha20Poly1305::open_inplace(&sk, &n, &tag, Some(&ad), &mut message)?;
+//! assert_eq!(b"Data to protect", &message);
+//!
 //! # }
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`XChaCha20Poly1305`]: xchacha20poly1305
 //! [`POLY1305_OUTSIZE`]: super::mac::poly1305::POLY1305_OUTSIZE
-//! [`seal()`]: chacha20poly1305::seal
-//! [`open()`]: chacha20poly1305::open
 //! [RFC]: https://tools.ietf.org/html/rfc8439#section-3
 //! [libsodium docs]: https://download.libsodium.org/doc/secret-key_cryptography/aead#additional-data
 //! [`P_MAX`]: chacha20poly1305::P_MAX
 //! [`A_MAX`]: chacha20poly1305::A_MAX
 //! [`C_MAX`]: chacha20poly1305::C_MAX
+//! [`ChaCha20Poly1305::open()`]: chacha20poly1305::ChaCha20Poly1305::open()
+//! [`ChaCha20Poly1305::open_inplace()`]: chacha20poly1305::ChaCha20Poly1305::open_inplace()
+//! [`ChaCha20Poly1305::seal()`]: chacha20poly1305::ChaCha20Poly1305::seal()
 
-use crate::ZeroizeWrap;
+use crate::hazardous::mac::poly1305::POLY1305_BLOCKSIZE;
+pub use crate::hazardous::mac::poly1305::Tag;
 pub use crate::hazardous::stream::chacha20::{Nonce, SecretKey};
+use crate::util::xor_slices;
 use crate::{
     errors::UnknownCryptoError,
     hazardous::{
         mac::poly1305::{OneTimeKey, POLY1305_KEYSIZE, POLY1305_OUTSIZE, Poly1305},
-        stream::chacha20::{self, CHACHA_BLOCKSIZE, ChaCha20},
+        stream::chacha20::{CHACHA_BLOCKSIZE, ChaCha20},
     },
-    util,
 };
 use core::convert::TryInto;
 
@@ -137,173 +144,286 @@ pub const C_MAX: u64 = P_MAX + (POLY1305_OUTSIZE as u64);
 /// The maximum size of the associated data (see [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439#section-2.8)).
 pub const A_MAX: u64 = u64::MAX;
 
-/// Poly1305 key generation using IETF ChaCha20.
-pub(crate) fn poly1305_key_gen(
-    ctx: &mut ChaCha20,
-    tmp_buffer: &mut ZeroizeWrap<[u8; CHACHA_BLOCKSIZE]>,
-) -> Result<OneTimeKey, UnknownCryptoError> {
-    ctx.keystream_block(AUTH_CTR, tmp_buffer.as_mut());
-    OneTimeKey::try_from(&tmp_buffer[..POLY1305_KEYSIZE])
-}
+#[derive(Debug)]
+/// ChaCha20Poly1305 encryption and authentication as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
+pub struct ChaCha20Poly1305 {}
 
-/// Authenticates the ciphertext, ad and their lengths.
-pub(crate) fn process_authentication(
-    auth_ctx: &mut Poly1305,
-    ad: &[u8],
-    ciphertext: &[u8],
-) -> Result<(), UnknownCryptoError> {
-    auth_ctx.process_pad_to_blocksize(ad)?;
-    auth_ctx.process_pad_to_blocksize(ciphertext)?;
-
-    let (ad_len, ct_len): (u64, u64) = match (ad.len().try_into(), ciphertext.len().try_into()) {
-        (Ok(alen), Ok(clen)) => (alen, clen),
-        _ => return Err(UnknownCryptoError),
-    };
-
-    let mut tmp_pad = [0u8; 16];
-    tmp_pad[0..8].copy_from_slice(&ad_len.to_le_bytes());
-    tmp_pad[8..16].copy_from_slice(&ct_len.to_le_bytes());
-    auth_ctx.update(tmp_pad.as_ref())
-}
-
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// AEAD ChaCha20Poly1305 encryption and authentication as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub fn seal(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    plaintext: &[u8],
-    ad: Option<&[u8]>,
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    if u64::try_from(plaintext.len()).map_err(|_| UnknownCryptoError)? > P_MAX {
-        return Err(UnknownCryptoError);
-    }
-
-    let ad = ad.unwrap_or(&[0u8; 0]);
-    #[allow(clippy::absurd_extreme_comparisons)]
-    if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
-        return Err(UnknownCryptoError);
-    }
-
-    match plaintext.len().checked_add(POLY1305_OUTSIZE) {
-        Some(out_min_len) => {
-            if dst_out.len() < out_min_len {
-                return Err(UnknownCryptoError);
-            }
-        }
-        None => return Err(UnknownCryptoError),
-    };
-
-    let mut stream = ChaCha20::new(secret_key.unprotected_as_ref(), nonce.as_ref(), true)?;
-    let mut tmp = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-
-    let mut auth_ctx = Poly1305::new(&poly1305_key_gen(&mut stream, &mut tmp)?);
-    let ad_len = ad.len();
-    let ct_len = plaintext.len();
-
-    auth_ctx.process_pad_to_blocksize(ad)?;
-
-    if ct_len != 0 {
-        for (ctr, (p_block, c_block)) in plaintext
-            .chunks(CHACHA_BLOCKSIZE)
-            .zip(dst_out.chunks_mut(CHACHA_BLOCKSIZE))
-            .enumerate()
-        {
-            match ENC_CTR.checked_add(ctr as u32) {
-                Some(counter) => {
-                    // See https://github.com/orion-rs/orion/issues/308
-                    stream.next_produceable()?;
-                    // We know at this point that:
-                    // 1) ENC_CTR + ctr does __not__ overflow/panic
-                    // 2) ChaCha20 instance will not panic on the next keystream produced
-
-                    // Copy keystream directly into the dst_out block if there is
-                    // enough space, to avoid copying from `tmp` each time and only
-                    // on the last block instead. `c_block` must be full blocksize,
-                    // or we leave behind keystream data in it, if `p_block` is not full length
-                    // while `c_block` is.
-                    if p_block.len() == CHACHA_BLOCKSIZE && c_block.len() == CHACHA_BLOCKSIZE {
-                        stream.keystream_block(counter, c_block);
-                        xor_slices!(p_block, c_block);
-                        auth_ctx.update(c_block)?;
-                    }
-
-                    // We only pad this last block to the Poly1305 blocksize since `CHACHA_BLOCKSIZE`
-                    // already is evenly divisible by 16, so the previous full-length blocks do not matter.
-                    if p_block.len() < CHACHA_BLOCKSIZE {
-                        stream.keystream_block(counter, tmp.as_mut());
-                        xor_slices!(p_block, tmp.as_mut());
-                        c_block[..p_block.len()].copy_from_slice(&tmp.as_ref()[..p_block.len()]);
-                        auth_ctx.process_pad_to_blocksize(&c_block[..p_block.len()])?;
-                    }
-                }
-                None => return Err(UnknownCryptoError),
-            }
-        }
-    }
-
-    let (adlen, ctlen): (u64, u64) = match (ad_len.try_into(), ct_len.try_into()) {
-        (Ok(alen), Ok(clen)) => (alen, clen),
-        _ => return Err(UnknownCryptoError),
-    };
-
-    let mut tmp_pad = [0u8; 16];
-    tmp_pad[0..8].copy_from_slice(&adlen.to_le_bytes());
-    tmp_pad[8..16].copy_from_slice(&ctlen.to_le_bytes());
-    auth_ctx.update(tmp_pad.as_ref())?;
-
-    dst_out[ct_len..(ct_len + POLY1305_OUTSIZE)]
-        .copy_from_slice(auth_ctx.finalize()?.unprotected_as_ref());
-
-    Ok(())
-}
-
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// AEAD ChaCha20Poly1305 decryption and authentication as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub fn open(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    ciphertext_with_tag: &[u8],
-    ad: Option<&[u8]>,
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    if u64::try_from(ciphertext_with_tag.len()).map_err(|_| UnknownCryptoError)? > C_MAX {
-        return Err(UnknownCryptoError);
-    }
-    let ad = ad.unwrap_or(&[0u8; 0]);
-    #[allow(clippy::absurd_extreme_comparisons)]
-    if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
-        return Err(UnknownCryptoError);
-    }
-    if ciphertext_with_tag.len() < POLY1305_OUTSIZE {
-        return Err(UnknownCryptoError);
-    }
-    if dst_out.len() < ciphertext_with_tag.len() - POLY1305_OUTSIZE {
-        return Err(UnknownCryptoError);
-    }
-
-    let mut dec_ctx = ChaCha20::new(secret_key.unprotected_as_ref(), nonce.as_ref(), true)?;
-    let mut tmp = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-    let mut auth_ctx = Poly1305::new(&poly1305_key_gen(&mut dec_ctx, &mut tmp)?);
-
-    let ciphertext_len = ciphertext_with_tag.len() - POLY1305_OUTSIZE;
-    process_authentication(&mut auth_ctx, ad, &ciphertext_with_tag[..ciphertext_len])?;
-    util::secure_cmp(
-        auth_ctx.finalize()?.unprotected_as_ref(),
-        &ciphertext_with_tag[ciphertext_len..],
-    )?;
-
-    if ciphertext_len != 0 {
-        dst_out[..ciphertext_len].copy_from_slice(&ciphertext_with_tag[..ciphertext_len]);
-        chacha20::xor_keystream(
-            &mut dec_ctx,
+impl ChaCha20Poly1305 {
+    fn poly1305_key_gen(ctx: &mut ChaCha20) -> OneTimeKey {
+        ctx.set_position(AUTH_CTR);
+        ctx.keystream_block();
+        debug_assert_eq!(
+            ctx.position(),
             ENC_CTR,
-            tmp.as_mut(),
-            &mut dst_out[..ciphertext_len],
-        )?;
+            "ctx.keystream_block() did not advance internal counter"
+        );
+
+        let mut authsk = OneTimeKey::from([0u8; POLY1305_KEYSIZE]);
+        authsk
+            .data
+            .bytes
+            .copy_from_slice(&ctx.keystreamblock[..POLY1305_KEYSIZE]);
+
+        authsk
     }
 
-    Ok(())
+    /// Poly1305 key generation using IETF ChaCha20.
+    pub(crate) fn poly1305_init(ctx: &mut ChaCha20) -> Poly1305 {
+        Poly1305::new(&Self::poly1305_key_gen(ctx))
+    }
+
+    /// Authenticates the ciphertext, ad and their lengths.
+    pub(crate) fn process_authentication(
+        auth_ctx: &mut Poly1305,
+        ad: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<(), UnknownCryptoError> {
+        let (ad_len, ct_len): (u64, u64) = match (ad.len().try_into(), ciphertext.len().try_into())
+        {
+            (Ok(alen), Ok(clen)) => (alen, clen),
+            _ => return Err(UnknownCryptoError),
+        };
+
+        auth_ctx.process_pad_to_blocksize(ad)?;
+        auth_ctx.process_pad_to_blocksize(ciphertext)?;
+
+        debug_assert_eq!(size_of::<u64>() * 2, POLY1305_BLOCKSIZE);
+        let mut tmp_pad = [0u8; POLY1305_BLOCKSIZE];
+        tmp_pad[0..8].copy_from_slice(&ad_len.to_le_bytes());
+        tmp_pad[8..16].copy_from_slice(&ct_len.to_le_bytes());
+        auth_ctx.update(tmp_pad.as_ref())?;
+
+        Ok(())
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD ChaCha20Poly1305 encryption and authentication. Encrypt `bytes` in-place and return the authentication [`Tag`].
+    ///
+    /// # SECURITY:
+    /// If this returns [`UnknownCryptoError`], then not all `bytes` have been processed.
+    /// Take care to zero out the bytes if this contains sensitive information.
+    ///
+    /// This equates to enryption if `bytes` is the plaintext and decryption if `bytes`
+    /// is the ciphertext.
+    pub fn seal_inplace(
+        sk: &SecretKey,
+        n: &Nonce,
+        ad: Option<&[u8]>,
+        bytes: &mut [u8],
+    ) -> Result<Tag, UnknownCryptoError> {
+        if u64::try_from(bytes.len()).map_err(|_| UnknownCryptoError)? > P_MAX {
+            return Err(UnknownCryptoError);
+        }
+        let ad = ad.unwrap_or(&[0u8; 0]);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
+            return Err(UnknownCryptoError);
+        }
+        let (ad_len, ct_len): (u64, u64) = match (ad.len().try_into(), bytes.len().try_into()) {
+            (Ok(alen), Ok(clen)) => (alen, clen),
+            _ => return Err(UnknownCryptoError),
+        };
+
+        let mut streamctx = ChaCha20::new(sk, n);
+        let mut auth_ctx = Self::poly1305_init(&mut streamctx);
+
+        auth_ctx.process_pad_to_blocksize(ad)?;
+        debug_assert_eq!(streamctx.position(), ENC_CTR);
+        debug_assert_eq!(streamctx.keystream_remaining(), P_MAX);
+
+        let mut parts = bytes.chunks_mut(CHACHA_BLOCKSIZE).peekable();
+        while let Some(block) = parts.next() {
+            streamctx.keystream_block();
+            xor_slices(&streamctx.keystreamblock, block);
+
+            debug_assert!(
+                block.len() <= CHACHA_BLOCKSIZE,
+                "chunks_mut() violated contract"
+            );
+            if block.len() == CHACHA_BLOCKSIZE {
+                // Given CHACHA_BLOCKSIZE evenly divides POLY1305_BLOCKSIZE
+                // we can skip padding-checks here.
+                auth_ctx.update(block)?;
+            } else {
+                auth_ctx.process_pad_to_blocksize(block)?;
+                debug_assert!(parts.peek().is_none());
+            }
+
+            // The only time we don't want to error on this check
+            // is when we have self.streampos == u32::MAX and there's
+            // at most CHACHA_BLOCKSIZE amount of bytes to process.
+            if parts.peek().is_some() {
+                streamctx.next_producible()?;
+            }
+        }
+
+        debug_assert_eq!(size_of::<u64>() * 2, POLY1305_BLOCKSIZE);
+        let mut tmp_pad = [0u8; POLY1305_BLOCKSIZE];
+        tmp_pad[0..8].copy_from_slice(&ad_len.to_le_bytes());
+        tmp_pad[8..16].copy_from_slice(&ct_len.to_le_bytes());
+        auth_ctx.update(tmp_pad.as_ref())?;
+
+        auth_ctx.finalize()
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD ChaCha20Poly1305 encryption and authentication. Verify authenticity of `tag` and decrypt `bytes` in-place if
+    /// successful.
+    pub fn open_inplace(
+        sk: &SecretKey,
+        n: &Nonce,
+        tag: &Tag,
+        ad: Option<&[u8]>,
+        bytes: &mut [u8],
+    ) -> Result<(), UnknownCryptoError> {
+        if u64::try_from(bytes.len()).map_err(|_| UnknownCryptoError)? > P_MAX {
+            return Err(UnknownCryptoError);
+        }
+        let ad = ad.unwrap_or(&[0u8; 0]);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
+            return Err(UnknownCryptoError);
+        }
+
+        let mut streamctx = ChaCha20::new(sk, n);
+        let mut auth_ctx = Self::poly1305_init(&mut streamctx);
+
+        Self::process_authentication(&mut auth_ctx, ad, bytes)?;
+        if auth_ctx.finalize()? != *tag {
+            return Err(UnknownCryptoError);
+        }
+
+        debug_assert_eq!(streamctx.position(), ENC_CTR);
+        debug_assert_eq!(streamctx.keystream_remaining(), P_MAX);
+        streamctx.xor_keystream_into(bytes)?;
+
+        Ok(())
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD ChaCha20Poly1305 encryption and authentication as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
+    pub fn seal(
+        sk: &SecretKey,
+        n: &Nonce,
+        plaintext: &[u8],
+        ad: Option<&[u8]>,
+        dst_out: &mut [u8],
+    ) -> Result<(), UnknownCryptoError> {
+        if u64::try_from(plaintext.len()).map_err(|_| UnknownCryptoError)? > P_MAX {
+            return Err(UnknownCryptoError);
+        }
+        let ad = ad.unwrap_or(&[0u8; 0]);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
+            return Err(UnknownCryptoError);
+        }
+        match plaintext.len().checked_add(POLY1305_OUTSIZE) {
+            Some(out_min_len) => {
+                if dst_out.len() < out_min_len {
+                    return Err(UnknownCryptoError);
+                }
+            }
+            None => return Err(UnknownCryptoError),
+        };
+        let (ad_len, ct_len): (u64, u64) = match (ad.len().try_into(), plaintext.len().try_into()) {
+            (Ok(alen), Ok(clen)) => (alen, clen),
+            _ => return Err(UnknownCryptoError),
+        };
+
+        let mut streamctx = ChaCha20::new(sk, n);
+        let mut auth_ctx = Self::poly1305_init(&mut streamctx);
+
+        auth_ctx.process_pad_to_blocksize(ad)?;
+        debug_assert_eq!(streamctx.position(), ENC_CTR);
+        debug_assert_eq!(streamctx.keystream_remaining(), P_MAX);
+
+        let mut p_iter = plaintext.chunks(CHACHA_BLOCKSIZE).peekable();
+        let mut c_iter = dst_out[..plaintext.len()]
+            .chunks_mut(CHACHA_BLOCKSIZE)
+            .peekable();
+        while let (Some(p_block), Some(c_block)) = (p_iter.next(), c_iter.next()) {
+            debug_assert_eq!(p_block.len(), c_block.len());
+            debug_assert_eq!(p_iter.peek().is_some(), c_iter.peek().is_some());
+            streamctx.keystream_block();
+
+            c_block.copy_from_slice(p_block);
+            xor_slices(&streamctx.keystreamblock, c_block);
+
+            if c_block.len() == CHACHA_BLOCKSIZE {
+                auth_ctx.update(c_block)?;
+            } else {
+                auth_ctx.process_pad_to_blocksize(c_block)?;
+
+                debug_assert!(p_iter.peek().is_none());
+                debug_assert!(c_iter.peek().is_none());
+            }
+
+            // The only time we don't want to error on this check
+            // is when we have self.streampos == u32::MAX and there's
+            // at most CHACHA_BLOCKSIZE amount of bytes to process.
+            if c_iter.peek().is_some() {
+                streamctx.next_producible()?;
+            }
+        }
+
+        debug_assert_eq!(size_of::<u64>() * 2, POLY1305_BLOCKSIZE);
+        let mut tmp_pad = [0u8; POLY1305_BLOCKSIZE];
+        tmp_pad[0..8].copy_from_slice(&ad_len.to_le_bytes());
+        tmp_pad[8..16].copy_from_slice(&ct_len.to_le_bytes());
+        auth_ctx.update(tmp_pad.as_ref())?;
+
+        dst_out[plaintext.len()..(plaintext.len() + POLY1305_OUTSIZE)]
+            .copy_from_slice(auth_ctx.finalize()?.unprotected_as_ref());
+
+        Ok(())
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD ChaCha20Poly1305 decryption and authentication as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
+    pub fn open(
+        sk: &SecretKey,
+        n: &Nonce,
+        ciphertext_with_tag: &[u8],
+        ad: Option<&[u8]>,
+        dst_out: &mut [u8],
+    ) -> Result<(), UnknownCryptoError> {
+        if u64::try_from(ciphertext_with_tag.len()).map_err(|_| UnknownCryptoError)? > C_MAX {
+            return Err(UnknownCryptoError);
+        }
+        let ad = ad.unwrap_or(&[0u8; 0]);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if u64::try_from(ad.len()).map_err(|_| UnknownCryptoError)? > A_MAX {
+            return Err(UnknownCryptoError);
+        }
+        if ciphertext_with_tag.len() < POLY1305_OUTSIZE {
+            return Err(UnknownCryptoError);
+        }
+        if dst_out.len() < ciphertext_with_tag.len() - POLY1305_OUTSIZE {
+            return Err(UnknownCryptoError);
+        }
+
+        let mut streamctx = ChaCha20::new(sk, n);
+        let mut auth_ctx = Self::poly1305_init(&mut streamctx);
+
+        let ctlen = ciphertext_with_tag.len() - POLY1305_OUTSIZE;
+        Self::process_authentication(&mut auth_ctx, ad, &ciphertext_with_tag[..ctlen])?;
+        let tag = Tag::try_from(&ciphertext_with_tag[ctlen..ctlen + POLY1305_OUTSIZE])?;
+        if auth_ctx.finalize()? != tag {
+            return Err(UnknownCryptoError);
+        }
+
+        // NOTE: We could easily use Self::open_inplace() but that would require
+        // us to copy entire ciphertext over to dst _BEFORE_ authenticity checks,
+        // thus it seems more reliable to keep it equivalent in behavior to open()
+        // which doesn't touch the ret-buffer before auth check has passed.
+        dst_out[..ctlen].copy_from_slice(&ciphertext_with_tag[..ctlen]);
+
+        debug_assert_eq!(streamctx.position(), ENC_CTR);
+        debug_assert_eq!(streamctx.keystream_remaining(), P_MAX);
+        streamctx.xor_keystream_into(&mut dst_out[..ctlen])?;
+
+        Ok(())
+    }
 }
 
 // Testing public functions in the module.
@@ -311,24 +431,82 @@ pub fn open(
 #[cfg(feature = "safe_api")]
 mod public {
     use super::*;
-    use crate::test_framework::aead_interface::{AeadTestRunner, test_diff_params_err};
+    use crate::{
+        hazardous::{
+            mac::poly1305::Poly1305Tag,
+            stream::chacha20::{CHACHA_KEYSIZE, ChaCha20Key, ChaCha20Nonce, IETF_CHACHA_NONCESIZE},
+        },
+        test_framework::aead_interface::{AeadTestRunner, TestableAead},
+    };
+
+    const ZERO_KEY: [u8; CHACHA_KEYSIZE] = [0u8; CHACHA_KEYSIZE];
+    const ZERO_IETF_NONCE: [u8; IETF_CHACHA_NONCESIZE] = [0u8; IETF_CHACHA_NONCESIZE];
+
+    impl TestableAead for ChaCha20Poly1305 {
+        type Key = ChaCha20Key;
+        type Nonce = ChaCha20Nonce;
+        type Tag = Poly1305Tag;
+
+        fn _seal_inplace(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            ad: Option<&[u8]>,
+            bytes: &mut [u8],
+        ) -> Result<crate::Secret<Self::Tag>, UnknownCryptoError> {
+            ChaCha20Poly1305::seal_inplace(sk, n, ad, bytes)
+        }
+
+        fn _open_inplace(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            tag: &crate::Secret<Self::Tag>,
+            ad: Option<&[u8]>,
+            bytes: &mut [u8],
+        ) -> Result<(), UnknownCryptoError> {
+            ChaCha20Poly1305::open_inplace(sk, n, tag, ad, bytes)
+        }
+
+        fn _seal(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            plaintext: &[u8],
+            ad: Option<&[u8]>,
+            dst_out: &mut [u8],
+        ) -> Result<(), UnknownCryptoError> {
+            ChaCha20Poly1305::seal(sk, n, plaintext, ad, dst_out)
+        }
+
+        fn _open(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            ciphertext_with_tag: &[u8],
+            ad: Option<&[u8]>,
+            dst_out: &mut [u8],
+        ) -> Result<(), UnknownCryptoError> {
+            ChaCha20Poly1305::open(sk, n, ciphertext_with_tag, ad, dst_out)
+        }
+    }
+
+    #[test]
+    fn test_aead_interface() {
+        AeadTestRunner::<ChaCha20Poly1305, CHACHA_KEYSIZE, IETF_CHACHA_NONCESIZE, POLY1305_OUTSIZE>::run_all_tests(&[213u8; 512]);
+    }
+
+    #[test]
+    fn test_max_values() {
+        let sk = SecretKey::from(ZERO_KEY);
+        let nonce = Nonce::from(ZERO_IETF_NONCE);
+        let mut ctx = ChaCha20::new(&sk, &nonce);
+        ctx.set_position(ENC_CTR);
+
+        assert_eq!(ctx.keystream_remaining(), P_MAX);
+        assert_eq!(ctx.keystream_remaining() + POLY1305_OUTSIZE as u64, C_MAX);
+    }
 
     #[quickcheck]
     #[cfg(feature = "safe_api")]
-    fn prop_aead_interface(input: Vec<u8>, ad: Vec<u8>) -> bool {
-        let secret_key = SecretKey::generate().unwrap();
-        let nonce = Nonce::try_from(&[0u8; chacha20::IETF_CHACHA_NONCESIZE]).unwrap();
-        AeadTestRunner(
-            seal,
-            open,
-            secret_key,
-            nonce,
-            &input,
-            None,
-            POLY1305_OUTSIZE,
-            &ad,
-        );
-        test_diff_params_err(&seal, &open, &input, POLY1305_OUTSIZE);
+    fn prop_aead_interface(input: Vec<u8>) -> bool {
+        AeadTestRunner::<ChaCha20Poly1305, CHACHA_KEYSIZE, IETF_CHACHA_NONCESIZE, POLY1305_OUTSIZE>::run_all_tests(&input);
         true
     }
 }
@@ -340,85 +518,65 @@ mod test_vectors {
 
     #[test]
     fn rfc8439_poly1305_key_gen_1() {
-        let key = SecretKey::try_from(&[0u8; 32]).unwrap();
-        let nonce = Nonce::try_from(&[
+        let key = SecretKey::from([0u8; 32]);
+        let nonce = Nonce::from([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        ])
-        .unwrap();
+        ]);
         let expected = [
             0x76, 0xb8, 0xe0, 0xad, 0xa0, 0xf1, 0x3d, 0x90, 0x40, 0x5d, 0x6a, 0xe5, 0x53, 0x86,
             0xbd, 0x28, 0xbd, 0xd2, 0x19, 0xb8, 0xa0, 0x8d, 0xed, 0x1a, 0xa8, 0x36, 0xef, 0xcc,
             0x8b, 0x77, 0x0d, 0xc7,
         ];
 
-        let mut chacha20_ctx =
-            ChaCha20::new(key.unprotected_as_ref(), nonce.as_ref(), true).unwrap();
-        let mut tmp_block = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-
+        let mut chacha20_ctx = ChaCha20::new(&key, &nonce);
         assert_eq!(
-            poly1305_key_gen(&mut chacha20_ctx, &mut tmp_block)
-                .unwrap()
-                .unprotected_as_ref(),
+            ChaCha20Poly1305::poly1305_key_gen(&mut chacha20_ctx).unprotected_as_ref(),
             expected.as_ref()
         );
     }
 
     #[test]
     fn rfc8439_poly1305_key_gen_2() {
-        let key = SecretKey::try_from(&[
+        let key = SecretKey::from([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x01,
-        ])
-        .unwrap();
-        let nonce = Nonce::try_from(&[
+        ]);
+        let nonce = Nonce::from([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
-        ])
-        .unwrap();
+        ]);
         let expected = [
             0xec, 0xfa, 0x25, 0x4f, 0x84, 0x5f, 0x64, 0x74, 0x73, 0xd3, 0xcb, 0x14, 0x0d, 0xa9,
             0xe8, 0x76, 0x06, 0xcb, 0x33, 0x06, 0x6c, 0x44, 0x7b, 0x87, 0xbc, 0x26, 0x66, 0xdd,
             0xe3, 0xfb, 0xb7, 0x39,
         ];
 
-        let mut chacha20_ctx =
-            ChaCha20::new(key.unprotected_as_ref(), nonce.as_ref(), true).unwrap();
-        let mut tmp_block = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-
+        let mut chacha20_ctx = ChaCha20::new(&key, &nonce);
         assert_eq!(
-            poly1305_key_gen(&mut chacha20_ctx, &mut tmp_block)
-                .unwrap()
-                .unprotected_as_ref(),
+            ChaCha20Poly1305::poly1305_key_gen(&mut chacha20_ctx).unprotected_as_ref(),
             expected.as_ref()
         );
     }
 
     #[test]
     fn rfc8439_poly1305_key_gen_3() {
-        let key = SecretKey::try_from(&[
+        let key = SecretKey::from([
             0x1c, 0x92, 0x40, 0xa5, 0xeb, 0x55, 0xd3, 0x8a, 0xf3, 0x33, 0x88, 0x86, 0x04, 0xf6,
             0xb5, 0xf0, 0x47, 0x39, 0x17, 0xc1, 0x40, 0x2b, 0x80, 0x09, 0x9d, 0xca, 0x5c, 0xbc,
             0x20, 0x70, 0x75, 0xc0,
-        ])
-        .unwrap();
-        let nonce = Nonce::try_from(&[
+        ]);
+        let nonce = Nonce::from([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
-        ])
-        .unwrap();
+        ]);
         let expected = [
             0x96, 0x5e, 0x3b, 0xc6, 0xf9, 0xec, 0x7e, 0xd9, 0x56, 0x08, 0x08, 0xf4, 0xd2, 0x29,
             0xf9, 0x4b, 0x13, 0x7f, 0xf2, 0x75, 0xca, 0x9b, 0x3f, 0xcb, 0xdd, 0x59, 0xde, 0xaa,
             0xd2, 0x33, 0x10, 0xae,
         ];
 
-        let mut chacha20_ctx =
-            ChaCha20::new(key.unprotected_as_ref(), nonce.as_ref(), true).unwrap();
-        let mut tmp_block = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-
+        let mut chacha20_ctx = ChaCha20::new(&key, &nonce);
         assert_eq!(
-            poly1305_key_gen(&mut chacha20_ctx, &mut tmp_block)
-                .unwrap()
-                .unprotected_as_ref(),
+            ChaCha20Poly1305::poly1305_key_gen(&mut chacha20_ctx).unprotected_as_ref(),
             expected.as_ref()
         );
     }

--- a/src/hazardous/aead/streaming.rs
+++ b/src/hazardous/aead/streaming.rs
@@ -103,15 +103,15 @@
 //! ["secretstream" API]: https://download.libsodium.org/doc/secret-key_cryptography/secretstream
 
 use crate::errors::UnknownCryptoError;
-use crate::hazardous::aead::chacha20poly1305::poly1305_key_gen;
-use crate::hazardous::mac::poly1305::{POLY1305_OUTSIZE, Poly1305, Tag as Poly1305Tag};
+use crate::hazardous::aead::chacha20poly1305::ChaCha20Poly1305;
+use crate::hazardous::mac::poly1305::{POLY1305_OUTSIZE, Tag as Poly1305Tag};
 pub use crate::hazardous::stream::chacha20::SecretKey;
 use crate::hazardous::stream::chacha20::{
     CHACHA_BLOCKSIZE, CHACHA_KEYSIZE, ChaCha20, HCHACHA_NONCESIZE, IETF_CHACHA_NONCESIZE,
-    Nonce as IETFNonce, encrypt as chacha20_enc, encrypt_in_place as chacha20_xor_stream,
+    Nonce as IETFNonce,
 };
 pub use crate::hazardous::stream::xchacha20::Nonce;
-use crate::hazardous::stream::xchacha20::subkey_and_nonce;
+use crate::hazardous::stream::xchacha20::XChaCha20;
 use core::convert::TryFrom;
 use subtle::ConstantTimeEq;
 
@@ -222,15 +222,10 @@ impl StreamXChaCha20Poly1305 {
     ) -> Result<Poly1305Tag, UnknownCryptoError> {
         debug_assert!(text.len() >= textpos + msglen);
 
-        let mut chacha20_ctx = ChaCha20::new(
-            self.key.unprotected_as_ref(),
-            self.get_nonce().as_ref(),
-            true,
-        )?;
-        let mut tmp_block = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
+        let mut chacha20_ctx = ChaCha20::new(&self.key, &self.get_nonce());
+        let mut poly = ChaCha20Poly1305::poly1305_init(&mut chacha20_ctx);
 
         let mut pad = [0u8; 16];
-        let mut poly = Poly1305::new(&poly1305_key_gen(&mut chacha20_ctx, &mut tmp_block)?);
 
         poly.process_pad_to_blocksize(ad)?;
         poly.update(block)?;
@@ -272,7 +267,7 @@ impl StreamXChaCha20Poly1305 {
         inonce.copy_from_slice(&nonce.as_ref()[HCHACHA_NONCESIZE..]);
 
         Self {
-            key: subkey_and_nonce(secret_key, nonce).0,
+            key: XChaCha20::subkey_and_ietf_nonce(secret_key, nonce).0,
             counter: 1,
             inonce,
         }
@@ -285,7 +280,9 @@ impl StreamXChaCha20Poly1305 {
         new_key_and_inonce[..CHACHA_KEYSIZE].copy_from_slice(self.key.unprotected_as_ref());
         new_key_and_inonce[CHACHA_KEYSIZE..].copy_from_slice(&self.inonce);
 
-        chacha20_xor_stream(&self.key, &self.get_nonce(), 0, &mut new_key_and_inonce)?;
+        let mut ctx = ChaCha20::new(&self.key, &self.get_nonce());
+        debug_assert_eq!(ctx.position(), 0);
+        ctx.xor_keystream_into(&mut new_key_and_inonce)?;
 
         self.key = SecretKey::try_from(&new_key_and_inonce[..CHACHA_KEYSIZE])?;
         self.inonce
@@ -322,11 +319,15 @@ impl StreamXChaCha20Poly1305 {
         let nonce = self.get_nonce();
 
         block[0] = tag.as_byte();
-        chacha20_xor_stream(&self.key, &nonce, 1, &mut block)?;
+        let mut ctx = ChaCha20::new(&self.key, &nonce);
+        ctx.set_position(1);
+        ctx.xor_keystream_into(&mut block)?;
         dst_out[0] = block[0];
 
         if msglen != 0 {
-            chacha20_enc(&self.key, &nonce, 2, plaintext, &mut dst_out[TAG_SIZE..])?;
+            debug_assert_eq!(ctx.position(), 2);
+            dst_out[TAG_SIZE..macpos].copy_from_slice(plaintext);
+            ctx.xor_keystream_into(&mut dst_out[TAG_SIZE..macpos])?;
         }
 
         let mac = self.generate_auth_tag(dst_out, ad, msglen, &block, TAG_SIZE)?;
@@ -360,22 +361,23 @@ impl StreamXChaCha20Poly1305 {
         let nonce = self.get_nonce();
 
         block[0] = ciphertext[0];
-        chacha20_xor_stream(&self.key, &nonce, 1, &mut block)?;
+        let mut ctx = ChaCha20::new(&self.key, &nonce);
+        ctx.set_position(1);
+        ctx.xor_keystream_into(&mut block)?;
         let tag = StreamTag::try_from(block[0])?;
+
         block[0] = ciphertext[0];
         let mac = self.generate_auth_tag(ciphertext, ad, msglen, &block, TAG_SIZE)?;
         if !(mac == ciphertext[macpos..macpos + mac.len()]) {
             return Err(UnknownCryptoError);
         }
+
         if msglen != 0 {
-            chacha20_enc(
-                &self.key,
-                &nonce,
-                2,
-                &ciphertext[TAG_SIZE..(TAG_SIZE + msglen)],
-                dst_out,
-            )?;
+            debug_assert_eq!(ctx.position(), 2);
+            dst_out[..msglen].copy_from_slice(&ciphertext[TAG_SIZE..(TAG_SIZE + msglen)]);
+            ctx.xor_keystream_into(&mut dst_out[..msglen])?;
         }
+
         self.advance_state(&mac, &tag)?;
 
         Ok(tag)
@@ -432,9 +434,11 @@ mod public {
 
         #[quickcheck]
         fn prop_aead_interface(input: Vec<u8>, ad: Vec<u8>) -> bool {
+            // TODO(brycx): Save the old AeadTestRunner for use with this and CAE? This one doesn't seem worth migrating):
+            // Potentially, we could also drop support for this if no users.
             let secret_key = SecretKey::generate().unwrap();
             let nonce = Nonce::generate().unwrap();
-            AeadTestRunner(seal, open, secret_key, nonce, &input, None, ABYTES, &ad);
+            BufferedOnlyAeadTestRunner(seal, open, secret_key, nonce, &input, None, ABYTES, &ad);
 
             true
         }

--- a/src/hazardous/aead/xchacha20poly1305.rs
+++ b/src/hazardous/aead/xchacha20poly1305.rs
@@ -21,14 +21,16 @@
 // SOFTWARE.
 
 //! # Parameters:
-//! - `secret_key`: The secret key.
-//! - `nonce`: The nonce value.
+//! - `sk`: The secret key.
+//! - `n`: The nonce value.
 //! - `ad`: Additional data to authenticate (this is not encrypted and can be [`None`]).
 //! - `ciphertext_with_tag`: The encrypted data with the corresponding 16 byte
 //!   Poly1305 tag appended to it.
 //! - `plaintext`: The data to be encrypted.
 //! - `dst_out`: Destination array that will hold the
 //!   `ciphertext_with_tag`/`plaintext` after encryption/decryption.
+//! - `bytes`: Bytes that are either encrypted or decrypted.
+//! - `tag`: The Poly1305 tag used for authenticity verification when using [`XChaCha20Poly1305::open_inplace()`].
 //!
 //! `ad`: "A typical use for these data is to authenticate version numbers,
 //! timestamps or monotonically increasing counters in order to discard previous
@@ -39,20 +41,16 @@
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`seal()`].
+//! - The length of `dst_out` is less than `plaintext` + [`POLY1305_OUTSIZE`] when calling [`XChaCha20Poly1305::seal()`].
 //! - The length of `dst_out` is less than `ciphertext_with_tag` - [`POLY1305_OUTSIZE`] when
-//!   calling [`open()`].
-//! - The length of the `ciphertext_with_tag` is not at least [`POLY1305_OUTSIZE`].
-//! - The received tag does not match the calculated tag when  calling [`open()`].
-//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`seal()`].
-//! - Converting `usize` to `u64` would be a lossy conversion.
-//! - `plaintext.len() >` [`chacha20poly1305::P_MAX`]
-//! - `ad.len() >` [`chacha20poly1305::A_MAX`]
-//! - `ciphertext_with_tag.len() >` [`chacha20poly1305::C_MAX`]
-//!
-//! # Panics:
-//! A panic will occur if:
-//! - More than `2^32-1 * 64` bytes of data are processed.
+//!   calling [`XChaCha20Poly1305::open()`].
+//! - The length of `ciphertext_with_tag` is not at least [`POLY1305_OUTSIZE`].
+//! - The received tag does not match the calculated tag when  calling [`XChaCha20Poly1305::open()`]/[`XChaCha20Poly1305::open_inplace()`].
+//! - `plaintext.len()` + [`POLY1305_OUTSIZE`] overflows when  calling [`XChaCha20Poly1305::seal()`].
+//! - Converting [`usize`] to [`u64`] would be a lossy conversion.
+//! - `plaintext.len() >` [`P_MAX`]
+//! - `ad.len() >` [`A_MAX`]
+//! - `ciphertext_with_tag.len() >` [`C_MAX`]
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
@@ -66,88 +64,179 @@
 //! # Example:
 //! ```rust
 //! # #[cfg(feature = "safe_api")] {
-//! use orion::hazardous::aead;
+//! use orion::hazardous::aead::xchacha20poly1305::{SecretKey, Nonce, XChaCha20Poly1305};
 //!
-//! let secret_key = aead::xchacha20poly1305::SecretKey::generate()?;
-//! let nonce = aead::xchacha20poly1305::Nonce::generate()?;
+//! let sk = SecretKey::generate()?;
+//! let n = Nonce::generate()?;
 //! let ad = "Additional data".as_bytes();
 //! let message = "Data to protect".as_bytes();
 //!
+//! // With output buffer:
+//!
 //! // Length of the above message is 15 and then we accommodate 16 for the Poly1305
 //! // tag.
-//!
 //! let mut dst_out_ct = [0u8; 15 + 16];
 //! let mut dst_out_pt = [0u8; 15];
 //! // Encrypt and place ciphertext + tag in dst_out_ct
-//! aead::xchacha20poly1305::seal(&secret_key, &nonce, message, Some(&ad), &mut dst_out_ct)?;
+//! XChaCha20Poly1305::seal(&sk, &n, message, Some(&ad), &mut dst_out_ct)?;
 //! // Verify tag, if correct then decrypt and place message in dst_out_pt
-//! aead::xchacha20poly1305::open(&secret_key, &nonce, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
-//!
+//! XChaCha20Poly1305::open(&sk, &n, &dst_out_ct, Some(&ad), &mut dst_out_pt)?;
 //! assert_eq!(dst_out_pt.as_ref(), message.as_ref());
+//!
+//! // In-place:
+//! let mut message: [u8; 15] = *b"Data to protect";
+//! let tag = XChaCha20Poly1305::seal_inplace(&sk, &n, Some(&ad), &mut message)?;
+//! assert_eq!(&dst_out_ct[..15], &message);
+//! XChaCha20Poly1305::open_inplace(&sk, &n, &tag, Some(&ad), &mut message)?;
+//! assert_eq!(b"Data to protect", &message);
+//!
 //! # }
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: super::stream::chacha20::SecretKey::generate
 //! [`Nonce::generate()`]: super::stream::xchacha20::Nonce::generate
 //! [`POLY1305_OUTSIZE`]: super::mac::poly1305::POLY1305_OUTSIZE
-//! [`seal()`]: xchacha20poly1305::seal
-//! [`open()`]: xchacha20poly1305::open
 //! [libsodium docs]: https://download.libsodium.org/doc/secret-key_cryptography/aead#additional-data
+//! [`P_MAX`]: chacha20poly1305::P_MAX
+//! [`A_MAX`]: chacha20poly1305::A_MAX
+//! [`C_MAX`]: chacha20poly1305::C_MAX
+//! [`XChaCha20Poly1305::open()`]: xchacha20poly1305::XChaCha20Poly1305::open()
+//! [`XChaCha20Poly1305::open_inplace()`]: xchacha20poly1305::XChaCha20Poly1305::open_inplace()
+//! [`XChaCha20Poly1305::seal()`]: xchacha20poly1305::XChaCha20Poly1305::seal()
 
-use crate::hazardous::stream::xchacha20::subkey_and_nonce;
+use crate::errors::UnknownCryptoError;
+pub use crate::hazardous::mac::poly1305::Tag;
 pub use crate::hazardous::stream::{chacha20::SecretKey, xchacha20::Nonce};
-use crate::{errors::UnknownCryptoError, hazardous::aead::chacha20poly1305};
+use crate::hazardous::{aead::chacha20poly1305::ChaCha20Poly1305, stream::xchacha20::XChaCha20};
 
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// AEAD XChaCha20Poly1305 encryption as specified in the [draft RFC](https://github.com/bikeshedders/xchacha-rfc).
-pub fn seal(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    plaintext: &[u8],
-    ad: Option<&[u8]>,
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-    chacha20poly1305::seal(&subkey, &ietf_nonce, plaintext, ad, dst_out)
-}
+#[derive(Debug)]
+/// XChaCha20Poly1305 encryption and authentication as specified in the [draft RFC](https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03).
+pub struct XChaCha20Poly1305 {}
 
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// AEAD XChaCha20Poly1305 decryption as specified in the [draft RFC](https://github.com/bikeshedders/xchacha-rfc).
-pub fn open(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    ciphertext_with_tag: &[u8],
-    ad: Option<&[u8]>,
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-    chacha20poly1305::open(&subkey, &ietf_nonce, ciphertext_with_tag, ad, dst_out)
+impl XChaCha20Poly1305 {
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD XChaCha20Poly1305 encryption and authentication. Encrypt `bytes` in-place and return the authentication [`Tag`].
+    ///
+    /// # SECURITY:
+    /// If this returns [`UnknownCryptoError`], then not all `bytes` have been processed.
+    /// Take care to zero out the bytes if this contains sensitive information.
+    ///
+    /// This equates to enryption if `bytes` is the plaintext and decryption if `bytes`
+    /// is the ciphertext.
+    pub fn seal_inplace(
+        sk: &SecretKey,
+        n: &Nonce,
+        ad: Option<&[u8]>,
+        bytes: &mut [u8],
+    ) -> Result<Tag, UnknownCryptoError> {
+        let (subkey, ietf_nonce) = XChaCha20::subkey_and_ietf_nonce(sk, n);
+        ChaCha20Poly1305::seal_inplace(&subkey, &ietf_nonce, ad, bytes)
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD XChaCha20Poly1305 encryption and authentication. Verify authenticity of `tag` and decrypt `bytes` in-place if
+    /// successful.
+    pub fn open_inplace(
+        sk: &SecretKey,
+        n: &Nonce,
+        tag: &Tag,
+        ad: Option<&[u8]>,
+        bytes: &mut [u8],
+    ) -> Result<(), UnknownCryptoError> {
+        let (subkey, ietf_nonce) = XChaCha20::subkey_and_ietf_nonce(sk, n);
+        ChaCha20Poly1305::open_inplace(&subkey, &ietf_nonce, tag, ad, bytes)
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD XChaCha20Poly1305 encryption and authentication as specified in the [draft RFC](https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03).
+    pub fn seal(
+        sk: &SecretKey,
+        n: &Nonce,
+        plaintext: &[u8],
+        ad: Option<&[u8]>,
+        dst_out: &mut [u8],
+    ) -> Result<(), UnknownCryptoError> {
+        let (subkey, ietf_nonce) = XChaCha20::subkey_and_ietf_nonce(sk, n);
+        ChaCha20Poly1305::seal(&subkey, &ietf_nonce, plaintext, ad, dst_out)
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// AEAD XChaCha20Poly1305 decryption and authentication as specified in the [draft RFC](https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03).
+    pub fn open(
+        sk: &SecretKey,
+        n: &Nonce,
+        ciphertext_with_tag: &[u8],
+        ad: Option<&[u8]>,
+        dst_out: &mut [u8],
+    ) -> Result<(), UnknownCryptoError> {
+        let (subkey, ietf_nonce) = XChaCha20::subkey_and_ietf_nonce(sk, n);
+        ChaCha20Poly1305::open(&subkey, &ietf_nonce, ciphertext_with_tag, ad, dst_out)
+    }
 }
 
 // Testing public functions in the module.
 #[cfg(test)]
-#[cfg(feature = "safe_api")]
 mod public {
     use super::*;
-    use crate::hazardous::mac::poly1305::POLY1305_OUTSIZE;
-    use crate::test_framework::aead_interface::{AeadTestRunner, test_diff_params_err};
+    use crate::hazardous::mac::poly1305::{POLY1305_OUTSIZE, Poly1305Tag};
+    use crate::hazardous::stream::chacha20::{CHACHA_KEYSIZE, ChaCha20Key};
+    use crate::hazardous::stream::xchacha20::{XCHACHA_NONCESIZE, XChaCha20Nonce};
+    use crate::test_framework::aead_interface::{AeadTestRunner, TestableAead};
+
+    impl TestableAead for XChaCha20Poly1305 {
+        type Key = ChaCha20Key;
+        type Nonce = XChaCha20Nonce;
+        type Tag = Poly1305Tag;
+
+        fn _seal_inplace(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            ad: Option<&[u8]>,
+            bytes: &mut [u8],
+        ) -> Result<crate::Secret<Self::Tag>, UnknownCryptoError> {
+            XChaCha20Poly1305::seal_inplace(sk, n, ad, bytes)
+        }
+
+        fn _open_inplace(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            tag: &crate::Secret<Self::Tag>,
+            ad: Option<&[u8]>,
+            bytes: &mut [u8],
+        ) -> Result<(), UnknownCryptoError> {
+            XChaCha20Poly1305::open_inplace(sk, n, tag, ad, bytes)
+        }
+
+        fn _seal(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            plaintext: &[u8],
+            ad: Option<&[u8]>,
+            dst_out: &mut [u8],
+        ) -> Result<(), UnknownCryptoError> {
+            XChaCha20Poly1305::seal(sk, n, plaintext, ad, dst_out)
+        }
+
+        fn _open(
+            sk: &crate::Secret<Self::Key>,
+            n: &crate::Public<Self::Nonce>,
+            ciphertext_with_tag: &[u8],
+            ad: Option<&[u8]>,
+            dst_out: &mut [u8],
+        ) -> Result<(), UnknownCryptoError> {
+            XChaCha20Poly1305::open(sk, n, ciphertext_with_tag, ad, dst_out)
+        }
+    }
+
+    #[test]
+    fn test_aead_interface() {
+        AeadTestRunner::<XChaCha20Poly1305, CHACHA_KEYSIZE, XCHACHA_NONCESIZE, POLY1305_OUTSIZE>::run_all_tests(&[213u8; 512]);
+    }
 
     #[quickcheck]
     #[cfg(feature = "safe_api")]
-    fn prop_aead_interface(input: Vec<u8>, ad: Vec<u8>) -> bool {
-        let secret_key = SecretKey::generate().unwrap();
-        let nonce = Nonce::generate().unwrap();
-        AeadTestRunner(
-            seal,
-            open,
-            secret_key,
-            nonce,
-            &input,
-            None,
-            POLY1305_OUTSIZE,
-            &ad,
-        );
-        test_diff_params_err(&seal, &open, &input, POLY1305_OUTSIZE);
+    fn prop_aead_interface(input: Vec<u8>) -> bool {
+        AeadTestRunner::<XChaCha20Poly1305, CHACHA_KEYSIZE, XCHACHA_NONCESIZE, POLY1305_OUTSIZE>::run_all_tests(&input);
         true
     }
 }

--- a/src/hazardous/cae/chacha20poly1305blake2b.rs
+++ b/src/hazardous/cae/chacha20poly1305blake2b.rs
@@ -119,12 +119,10 @@
 //! [partitioning oracle attack]: https://www.usenix.org/conference/usenixsecurity21/presentation/len
 
 use crate::errors::UnknownCryptoError;
-use crate::hazardous::aead;
-use crate::hazardous::aead::chacha20poly1305::{ENC_CTR, poly1305_key_gen, process_authentication};
+use crate::hazardous::aead::chacha20poly1305::{ChaCha20Poly1305, ENC_CTR};
 use crate::hazardous::hash::blake2::blake2b::Blake2b;
 use crate::hazardous::mac::poly1305::POLY1305_OUTSIZE;
-use crate::hazardous::mac::poly1305::Poly1305;
-use crate::hazardous::stream::chacha20::{self, CHACHA_BLOCKSIZE, ChaCha20};
+use crate::hazardous::stream::chacha20::ChaCha20;
 use crate::util;
 
 pub use crate::hazardous::aead::chacha20poly1305::A_MAX;
@@ -165,7 +163,7 @@ pub fn seal(
         None => return Err(UnknownCryptoError),
     };
 
-    aead::chacha20poly1305::seal(
+    ChaCha20Poly1305::seal(
         secret_key,
         nonce,
         plaintext,
@@ -214,12 +212,15 @@ pub fn open(
     blake2b.update(nonce.as_ref())?;
     blake2b.update(ad)?;
 
-    let mut dec_ctx = ChaCha20::new(secret_key.unprotected_as_ref(), nonce.as_ref(), true)?;
-    let mut tmp = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-    let mut auth_ctx = Poly1305::new(&poly1305_key_gen(&mut dec_ctx, &mut tmp)?);
+    let mut dec_ctx = ChaCha20::new(secret_key, nonce);
+    let mut auth_ctx = ChaCha20Poly1305::poly1305_init(&mut dec_ctx);
 
     let ciphertext_len = ciphertext_with_tag.len() - TAG_SIZE;
-    process_authentication(&mut auth_ctx, ad, &ciphertext_with_tag[..ciphertext_len])?;
+    ChaCha20Poly1305::process_authentication(
+        &mut auth_ctx,
+        ad,
+        &ciphertext_with_tag[..ciphertext_len],
+    )?;
 
     blake2b.update(auth_ctx.finalize()?.unprotected_as_ref())?;
 
@@ -228,14 +229,10 @@ pub fn open(
         &ciphertext_with_tag[ciphertext_len..],
     )?;
 
+    debug_assert_eq!(dec_ctx.position(), ENC_CTR);
     if ciphertext_len != 0 {
         dst_out[..ciphertext_len].copy_from_slice(&ciphertext_with_tag[..ciphertext_len]);
-        chacha20::xor_keystream(
-            &mut dec_ctx,
-            ENC_CTR,
-            tmp.as_mut(),
-            &mut dst_out[..ciphertext_len],
-        )?;
+        dec_ctx.xor_keystream_into(&mut dst_out[..ciphertext_len])?;
     }
 
     Ok(())
@@ -246,15 +243,16 @@ pub fn open(
 #[cfg(feature = "safe_api")]
 mod public {
     use super::*;
-    use crate::test_framework::aead_interface::{AeadTestRunner, test_diff_params_err};
+    use crate::hazardous::stream::chacha20;
+    use crate::test_framework::aead_interface::BufferedOnlyAeadTestRunner;
 
     #[quickcheck]
     #[cfg(feature = "safe_api")]
     fn prop_aead_interface(input: Vec<u8>, ad: Vec<u8>) -> bool {
+        // TODO(brycx): These are older tests (see mod-level todo about whether to remove these).
         let secret_key = SecretKey::generate().unwrap();
         let nonce = Nonce::try_from(&[0u8; chacha20::IETF_CHACHA_NONCESIZE]).unwrap();
-        AeadTestRunner(seal, open, secret_key, nonce, &input, None, TAG_SIZE, &ad);
-        test_diff_params_err(&seal, &open, &input, TAG_SIZE);
+        BufferedOnlyAeadTestRunner(seal, open, secret_key, nonce, &input, None, TAG_SIZE, &ad);
         true
     }
 }

--- a/src/hazardous/cae/mod.rs
+++ b/src/hazardous/cae/mod.rs
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// TODO: This is not used anywhere AFAICT. Should we perhaps drop these and wait for RFC?
+// None of the schemes outside Lightweight AEAD scheme competition seem to focus on this.
+
 #![cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 
 /// Fully-committing ChaCha20-Poly1305 with BLAKE2b based on the [CTX] construction by John Chan & Phillip Rogaway.

--- a/src/hazardous/cae/xchacha20poly1305blake2b.rs
+++ b/src/hazardous/cae/xchacha20poly1305blake2b.rs
@@ -107,15 +107,14 @@
 //! [partitioning oracle attack]: https://www.usenix.org/conference/usenixsecurity21/presentation/len
 
 use crate::errors::UnknownCryptoError;
-use crate::hazardous::aead;
 pub use crate::hazardous::aead::chacha20poly1305::A_MAX;
 pub use crate::hazardous::aead::chacha20poly1305::P_MAX;
-use crate::hazardous::aead::chacha20poly1305::{ENC_CTR, poly1305_key_gen, process_authentication};
+use crate::hazardous::aead::chacha20poly1305::{ChaCha20Poly1305, ENC_CTR};
 pub use crate::hazardous::cae::chacha20poly1305blake2b::{C_MAX, TAG_SIZE};
 use crate::hazardous::hash::blake2::blake2b::Blake2b;
-use crate::hazardous::mac::poly1305::{POLY1305_OUTSIZE, Poly1305};
-use crate::hazardous::stream::chacha20::{self, CHACHA_BLOCKSIZE, ChaCha20};
-use crate::hazardous::stream::xchacha20::subkey_and_nonce;
+use crate::hazardous::mac::poly1305::POLY1305_OUTSIZE;
+use crate::hazardous::stream::chacha20::ChaCha20;
+use crate::hazardous::stream::xchacha20::XChaCha20;
 pub use crate::hazardous::stream::{chacha20::SecretKey, xchacha20::Nonce};
 use crate::util;
 
@@ -147,8 +146,8 @@ pub fn seal(
         None => return Err(UnknownCryptoError),
     };
 
-    let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-    aead::chacha20poly1305::seal(
+    let (subkey, ietf_nonce) = XChaCha20::subkey_and_ietf_nonce(secret_key, nonce);
+    ChaCha20Poly1305::seal(
         &subkey,
         &ietf_nonce,
         plaintext,
@@ -197,13 +196,16 @@ pub fn open(
     blake2b.update(nonce.as_ref())?;
     blake2b.update(ad)?;
 
-    let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-    let mut dec_ctx = ChaCha20::new(subkey.unprotected_as_ref(), ietf_nonce.as_ref(), true)?;
-    let mut tmp = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-    let mut auth_ctx = Poly1305::new(&poly1305_key_gen(&mut dec_ctx, &mut tmp)?);
+    let (subkey, ietf_nonce) = XChaCha20::subkey_and_ietf_nonce(secret_key, nonce);
+    let mut dec_ctx = ChaCha20::new(&subkey, &ietf_nonce);
+    let mut auth_ctx = ChaCha20Poly1305::poly1305_init(&mut dec_ctx);
 
     let ciphertext_len = ciphertext_with_tag.len() - TAG_SIZE;
-    process_authentication(&mut auth_ctx, ad, &ciphertext_with_tag[..ciphertext_len])?;
+    ChaCha20Poly1305::process_authentication(
+        &mut auth_ctx,
+        ad,
+        &ciphertext_with_tag[..ciphertext_len],
+    )?;
 
     blake2b.update(auth_ctx.finalize()?.unprotected_as_ref())?;
 
@@ -212,14 +214,10 @@ pub fn open(
         &ciphertext_with_tag[ciphertext_len..],
     )?;
 
+    debug_assert_eq!(dec_ctx.position(), ENC_CTR);
     if ciphertext_len != 0 {
         dst_out[..ciphertext_len].copy_from_slice(&ciphertext_with_tag[..ciphertext_len]);
-        chacha20::xor_keystream(
-            &mut dec_ctx,
-            ENC_CTR,
-            tmp.as_mut(),
-            &mut dst_out[..ciphertext_len],
-        )?;
+        dec_ctx.xor_keystream_into(&mut dst_out[..ciphertext_len])?;
     }
 
     Ok(())
@@ -230,15 +228,15 @@ pub fn open(
 #[cfg(feature = "safe_api")]
 mod public {
     use super::*;
-    use crate::test_framework::aead_interface::{AeadTestRunner, test_diff_params_err};
+    use crate::test_framework::aead_interface::BufferedOnlyAeadTestRunner;
 
     #[quickcheck]
     #[cfg(feature = "safe_api")]
     fn prop_aead_interface(input: Vec<u8>, ad: Vec<u8>) -> bool {
+        // TODO(brycx): These are older tests (see mod-level todo about whether to remove these).
         let secret_key = SecretKey::generate().unwrap();
         let nonce = Nonce::generate().unwrap();
-        AeadTestRunner(seal, open, secret_key, nonce, &input, None, TAG_SIZE, &ad);
-        test_diff_params_err(&seal, &open, &input, TAG_SIZE);
+        BufferedOnlyAeadTestRunner(seal, open, secret_key, nonce, &input, None, TAG_SIZE, &ad);
         true
     }
 }

--- a/src/hazardous/hpke/x25519_sha256_chacha20poly1305.rs
+++ b/src/hazardous/hpke/x25519_sha256_chacha20poly1305.rs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 use crate::errors::UnknownCryptoError;
-use crate::hazardous::aead::chacha20poly1305;
+use crate::hazardous::aead::chacha20poly1305::{self, ChaCha20Poly1305};
 use crate::hazardous::hash::sha2::sha256::SHA256_OUTSIZE;
 use crate::hazardous::hpke::mode::private::*;
 use crate::hazardous::hpke::suite::private::*;
@@ -502,7 +502,7 @@ impl Suite for DHKEM_X25519_SHA256_CHACHA20 {
 
         let key = chacha20poly1305::SecretKey::from(self.key);
         let nonce = self.compute_nonce();
-        chacha20poly1305::seal(&key, &nonce, plaintext, Some(aad), out)?;
+        ChaCha20Poly1305::seal(&key, &nonce, plaintext, Some(aad), out)?;
 
         self.increment_seq()
     }
@@ -520,7 +520,7 @@ impl Suite for DHKEM_X25519_SHA256_CHACHA20 {
 
         let key = chacha20poly1305::SecretKey::from(self.key);
         let nonce = self.compute_nonce();
-        chacha20poly1305::open(&key, &nonce, ciphertext, Some(aad), out)?;
+        ChaCha20Poly1305::open(&key, &nonce, ciphertext, Some(aad), out)?;
 
         self.increment_seq()
     }

--- a/src/hazardous/mac/blake2b.rs
+++ b/src/hazardous/mac/blake2b.rs
@@ -130,7 +130,7 @@ impl serde::Serialize for Tag {
     where
         S: serde::ser::Serializer,
     {
-        let bytes: &[u8] = &self.data.as_ref();
+        let bytes: &[u8] = self.data.as_ref();
         bytes.serialize(serializer)
     }
 }

--- a/src/hazardous/mac/hmac.rs
+++ b/src/hazardous/mac/hmac.rs
@@ -301,7 +301,7 @@ pub mod sha256 {
         where
             S: serde::ser::Serializer,
         {
-            let bytes: &[u8] = &self.data.as_ref();
+            let bytes: &[u8] = self.data.as_ref();
             bytes.serialize(serializer)
         }
     }
@@ -649,7 +649,7 @@ pub mod sha384 {
         where
             S: serde::ser::Serializer,
         {
-            let bytes: &[u8] = &self.data.as_ref();
+            let bytes: &[u8] = self.data.as_ref();
             bytes.serialize(serializer)
         }
     }
@@ -996,7 +996,7 @@ pub mod sha512 {
         where
             S: serde::ser::Serializer,
         {
-            let bytes: &[u8] = &self.data.as_ref();
+            let bytes: &[u8] = self.data.as_ref();
             bytes.serialize(serializer)
         }
     }

--- a/src/hazardous/mac/poly1305.rs
+++ b/src/hazardous/mac/poly1305.rs
@@ -89,7 +89,7 @@ use fiat_crypto::poly1305_32::{
 use crate::generics::sealed::Data;
 
 /// The blocksize which Poly1305 operates on.
-const POLY1305_BLOCKSIZE: usize = 16;
+pub(crate) const POLY1305_BLOCKSIZE: usize = 16;
 /// The output size for Poly1305.
 pub const POLY1305_OUTSIZE: usize = 16;
 /// The key size for Poly1305.
@@ -154,7 +154,7 @@ impl serde::Serialize for Tag {
     where
         S: serde::ser::Serializer,
     {
-        let bytes: &[u8] = &self.data.as_ref();
+        let bytes: &[u8] = self.data.as_ref();
         bytes.serialize(serializer)
     }
 }
@@ -314,12 +314,14 @@ impl Poly1305 {
         state
     }
 
-    /// Update state with a `data` and pad it to blocksize with 0, if not
+    /// Update state with a `data` and pad it to blocksize with 0's, if not
     /// evenly divisible by blocksize.
     pub(crate) fn process_pad_to_blocksize(
         &mut self,
         data: &[u8],
     ) -> Result<(), UnknownCryptoError> {
+        debug_assert_eq!(self.leftover, 0);
+
         if self.is_finalized {
             return Err(UnknownCryptoError);
         }
@@ -338,6 +340,8 @@ impl Poly1305 {
             pad[..remaining.len()].copy_from_slice(remaining);
             self.process_block(&pad).unwrap();
         }
+
+        debug_assert_eq!(self.leftover, 0);
 
         Ok(())
     }

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -21,13 +21,10 @@
 // SOFTWARE.
 
 //! # Parameters:
-//! - `secret_key`: The secret key.
-//! - `nonce`: The nonce value.
-//! - `initial_counter`: The initial counter value. In most cases, this is `0`.
-//! - `ciphertext`: The encrypted data.
-//! - `plaintext`: The data to be encrypted.
-//! - `dst_out`: Destination array that will hold the ciphertext/plaintext after
-//!   encryption/decryption.
+//! - `sk`: The secret key.
+//! - `n`: The nonce value.
+//! - `blockctr`: The position within the keystream.
+//! - `bytes`: Bytes to apply the keystream to.
 //!
 //! `nonce`: "Counters and LFSRs are both acceptable ways of generating unique
 //! nonces, as is encrypting a counter using a block cipher with a 64-bit block
@@ -36,23 +33,14 @@
 //! because such a truncation may repeat after a short time." See [RFC]
 //! for more information.
 //!
-//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
-//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
-//!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
-//! - `plaintext` or `ciphertext` is empty.
-//! - The `initial_counter` is high enough to cause a potential overflow.
-//!
-//! Even though `dst_out` is allowed to be of greater length than `plaintext`,
-//! the `ciphertext` produced by `chacha20`/`xchacha20` will always be of the
-//! same length as the `plaintext`.
-//!
-//! # Panics:
-//! A panic will occur if:
-//! - More than `2^32-1` keystream blocks are processed or more than `2^32-1 * 64`
-//!   bytes of data are processed.
+//! - The [`ChaCha20::next_producible()`] returns err.
+//! - If a keystream block (64 bytes) has been generated with [`ChaCha20::position()`] [`u32::MAX`],
+//!   and [`ChaCha20::xor_keystream_into()`] is called subsequently. Generating the last keystream block
+//!   moves [`ChaCha20`] into an exhausted state, which is non-resettable. In this case, the key/nonce pair
+//!   has generated all possible keystream bytes and is thus not safe to use further.
+//!   This can be checked with [`ChaCha20::is_exhausted()`].
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
@@ -70,30 +58,40 @@
 //! # Example:
 //! ```rust
 //! # #[cfg(feature = "safe_api")] {
-//! use orion::hazardous::stream::chacha20;
+//! use orion::hazardous::stream::chacha20::{SecretKey, Nonce, ChaCha20};
 //!
-//! let secret_key = chacha20::SecretKey::generate()?;
-//!
+//! let sk = SecretKey::generate()?;
 //! // WARNING: This nonce is only meant for demonstration and should not
 //! // be repeated. Please read the security section.
-//! let nonce = chacha20::Nonce::from([0u8; 12]);
-//! let message = "Data to protect".as_bytes();
+//! let n = Nonce::from([0u8; 12]);
+//! let mut ctx = ChaCha20::new(&sk, &n);
 //!
-//! // The length of this message is 15.
 //!
-//! let mut dst_out_pt = [0u8; 15];
-//! let mut dst_out_ct = [0u8; 15];
+//! // Encrypting a message:
+//! let mut message: [u8; 15] = *b"Data to protect";
+//! ctx.xor_keystream_into(&mut message)?;
+//! // Decrypt (re-apply keystream):
+//! ctx.set_position(0); // reset to beginning
+//! ctx.xor_keystream_into(&mut message)?;
 //!
-//! chacha20::encrypt(&secret_key, &nonce, 0, message, &mut dst_out_ct)?;
+//! assert_eq!("Data to protect".as_bytes(), message);
 //!
-//! chacha20::decrypt(&secret_key, &nonce, 0, &dst_out_ct, &mut dst_out_pt)?;
+//! // Seeking ahead in keystream. This example generates the 256th keystream block (64 bytes):
+//! ctx.set_position(256);
+//! let mut keystream_block = [0u8; 64];
+//! ctx.xor_keystream_into(&mut keystream_block)?;
 //!
-//! assert_eq!(dst_out_pt, message);
 //! # }
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: chacha20::SecretKey::generate()
 //! [`XChaCha20Poly1305`]: super::aead::xchacha20poly1305
+//! [`ChaCha20`]: chacha20::ChaCha20
+//! [`ChaCha20::xor_keystream_into()`]: chacha20::ChaCha20::xor_keystream_into()
+//! [`ChaCha20::position()`]: chacha20::ChaCha20::position()
+//! [`ChaCha20::is_exhausted()`]: chacha20::ChaCha20::is_exhausted()
+//! [`ChaCha20::next_producible()`]: chacha20::ChaCha20::next_producible()
+
 //! [RFC]: https://tools.ietf.org/html/rfc8439
 use crate::GenerateSecret;
 use crate::errors::UnknownCryptoError;
@@ -103,6 +101,8 @@ use crate::generics::sealed::Sealed;
 use crate::generics::{ByteArrayData, Public, Secret, TypeSpec};
 use crate::util::endianness::load_u32_le;
 use crate::util::u32x4::U32x4;
+use crate::util::xor_slices;
+use core::fmt::Debug;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -111,7 +111,7 @@ pub const CHACHA_KEYSIZE: usize = 32;
 /// The nonce size for IETF ChaCha20.
 pub const IETF_CHACHA_NONCESIZE: usize = 12;
 /// The blocksize which ChaCha20 operates on.
-pub(crate) const CHACHA_BLOCKSIZE: usize = 64;
+pub const CHACHA_BLOCKSIZE: usize = 64;
 /// The size of the subkey that HChaCha20 returns.
 const HCHACHA_OUTSIZE: usize = 32;
 /// The nonce size for HChaCha20.
@@ -199,102 +199,105 @@ macro_rules! DOUBLE_ROUND {
         $r3 = $r3.shl_1();
     };
 }
-pub(crate) struct ChaCha20 {
+
+#[derive(Clone)]
+/// IETF ChaCha20 as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
+pub struct ChaCha20 {
     state: [U32x4; 4],
-    internal_counter: u32,
-    is_ietf: bool,
+    pub(crate) keystreamblock: [u8; CHACHA_BLOCKSIZE],
+    streampos: u32,
+    /// Flag to track if the final block counter has been used.
+    /// If we didn't track, we could end up writing the same keystream
+    /// block to CHACHA_BLOCKSIZE-sized output chunks over multiple
+    /// xor_keystream_into() calls. As the next_produceable() can
+    /// only be called if more bytes that the last block is requested.
+    ///
+    /// This is meant to be un-resettable, because using a key/nonce pair
+    /// for an exhausted stream re-generates previous keystream bytes.
+    exhausted: bool,
+}
+
+impl Debug for ChaCha20 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{} state: {{***OMITTED***}}, keystreamblock: {{***OMITTED***}}, streampos: {:?}, exhausted: {:?}",
+            stringify!(ChaCha20),
+            self.streampos,
+            self.exhausted,
+        )
+    }
 }
 
 #[cfg(feature = "zeroize")]
+impl Zeroize for ChaCha20 {
+    fn zeroize(&mut self) {
+        self.state.iter_mut().zeroize();
+        self.keystreamblock.iter_mut().zeroize();
+    }
+}
+
 impl Drop for ChaCha20 {
     fn drop(&mut self) {
-        self.state.iter_mut().zeroize();
+        #[cfg(feature = "zeroize")]
+        self.zeroize();
     }
 }
 
 impl ChaCha20 {
-    #[allow(clippy::unreadable_literal)]
-    /// Initialize either a ChaCha or HChaCha state with a `secret_key` and
-    /// `nonce`.
-    pub(crate) fn new(sk: &[u8], n: &[u8], is_ietf: bool) -> Result<Self, UnknownCryptoError> {
-        debug_assert_eq!(sk.len(), CHACHA_KEYSIZE);
-        if (n.len() != IETF_CHACHA_NONCESIZE) && is_ietf {
-            return Err(UnknownCryptoError);
-        }
-        if (n.len() != HCHACHA_NONCESIZE) && !is_ietf {
-            return Err(UnknownCryptoError);
-        }
-
+    /// Create a new [`ChaCha20`] instance.
+    pub fn new(sk: &SecretKey, n: &Nonce) -> Self {
         // Row 0 with constants.
         let r0 = U32x4(0x61707865, 0x3320646e, 0x79622d32, 0x6b206574);
 
         // Row 1 and 2 with secret key.
         let r1 = U32x4(
-            load_u32_le(&sk[0..4]),
-            load_u32_le(&sk[4..8]),
-            load_u32_le(&sk[8..12]),
-            load_u32_le(&sk[12..16]),
+            load_u32_le(&sk.data.bytes[0..4]),
+            load_u32_le(&sk.data.bytes[4..8]),
+            load_u32_le(&sk.data.bytes[8..12]),
+            load_u32_le(&sk.data.bytes[12..16]),
         );
 
         let r2 = U32x4(
-            load_u32_le(&sk[16..20]),
-            load_u32_le(&sk[20..24]),
-            load_u32_le(&sk[24..28]),
-            load_u32_le(&sk[28..32]),
+            load_u32_le(&sk.data.bytes[16..20]),
+            load_u32_le(&sk.data.bytes[20..24]),
+            load_u32_le(&sk.data.bytes[24..28]),
+            load_u32_le(&sk.data.bytes[28..32]),
         );
 
-        // Row 3 with counter and nonce if IETF,
-        // but only nonce if HChaCha20.
-        let r3 = if is_ietf {
-            U32x4(
-                0, // Default counter
-                load_u32_le(&n[0..4]),
-                load_u32_le(&n[4..8]),
-                load_u32_le(&n[8..12]),
-            )
-        } else {
-            U32x4(
-                load_u32_le(&n[0..4]),
-                load_u32_le(&n[4..8]),
-                load_u32_le(&n[8..12]),
-                load_u32_le(&n[12..16]),
-            )
-        };
+        let r3 = U32x4(
+            0, // Default counter
+            load_u32_le(&n.data.bytes[0..4]),
+            load_u32_le(&n.data.bytes[4..8]),
+            load_u32_le(&n.data.bytes[8..12]),
+        );
 
-        Ok(Self {
+        Self {
             state: [r0, r1, r2, r3],
-            internal_counter: 0,
-            is_ietf,
-        })
+            keystreamblock: [0u8; CHACHA_BLOCKSIZE],
+            streampos: 0,
+            exhausted: false,
+        }
+    }
+
+    /// Return `true` if the last keystream block has been generated.
+    pub fn is_exhausted(&self) -> bool {
+        self.exhausted
     }
 
     /// Check that we can produce one more keystream block, given the current state.
     ///
-    /// If the internal counter would overflow, we return an error.
-    pub(crate) fn next_produceable(&self) -> Result<(), UnknownCryptoError> {
-        if self.internal_counter.checked_add(1).is_none() {
+    /// Return error if advancing the internal state position by one would overflow [`u32::MAX`],
+    /// or the keystream has been exhausted (see [`Self::is_exhausted`]).
+    pub fn next_producible(&self) -> Result<(), UnknownCryptoError> {
+        if self.streampos.checked_add(1).is_none() || self.exhausted {
             Err(UnknownCryptoError)
         } else {
             Ok(())
         }
     }
 
-    /// Process the next keystream and copy into destination array.
-    pub(crate) fn keystream_block(&mut self, block_counter: u32, inplace: &mut [u8]) {
-        debug_assert!(if self.is_ietf {
-            inplace.len() == CHACHA_BLOCKSIZE
-        } else {
-            inplace.len() == HCHACHA_OUTSIZE
-        });
-
-        if self.is_ietf {
-            self.state[3].0 = block_counter;
-        }
-
-        // If this panics, max amount of keystream blocks
-        // have been retrieved.
-        self.internal_counter = self.internal_counter.checked_add(1).unwrap();
-
+    fn apply_rounds(&self) -> [U32x4; 4] {
         let mut wr0 = self.state[0];
         let mut wr1 = self.state[1];
         let mut wr2 = self.state[2];
@@ -311,135 +314,198 @@ impl ChaCha20 {
         DOUBLE_ROUND!(wr0, wr1, wr2, wr3);
         DOUBLE_ROUND!(wr0, wr1, wr2, wr3);
 
-        let mut iter = inplace.chunks_exact_mut(16);
+        [wr0, wr1, wr2, wr3]
+    }
 
-        if self.is_ietf {
-            wr0 = wr0.wrapping_add(self.state[0]);
-            wr1 = wr1.wrapping_add(self.state[1]);
-            wr2 = wr2.wrapping_add(self.state[2]);
-            wr3 = wr3.wrapping_add(self.state[3]);
+    /// HChaCha20 as specified in the [draft-RFC](https://github.com/bikeshedders/xchacha-rfc/blob/master).
+    pub(crate) fn hchacha(sk: &SecretKey, n: &[u8; HCHACHA_NONCESIZE]) -> [u8; HCHACHA_OUTSIZE] {
+        let mut ctx = ChaCha20::new(sk, &Nonce::from([0u8; IETF_CHACHA_NONCESIZE]));
+        ctx.state[3] = U32x4(
+            load_u32_le(&n[0..4]),
+            load_u32_le(&n[4..8]),
+            load_u32_le(&n[8..12]),
+            load_u32_le(&n[12..16]),
+        );
 
-            wr0.store_into_le(iter.next().unwrap());
-            wr1.store_into_le(iter.next().unwrap());
-            wr2.store_into_le(iter.next().unwrap());
-            wr3.store_into_le(iter.next().unwrap());
+        #[cfg(feature = "zeroize")]
+        let mut wstate = ctx.apply_rounds();
+        #[cfg(not(feature = "zeroize"))]
+        let wstate = ctx.apply_rounds();
+
+        let mut out = [0u8; HCHACHA_OUTSIZE];
+        wstate[0].store_into_le(&mut out[..16]);
+        wstate[3].store_into_le(&mut out[16..]);
+
+        #[cfg(feature = "zeroize")]
+        wstate.iter_mut().zeroize();
+
+        out
+    }
+
+    /// Process the next keystream and advance `self.streampos`.
+    pub(crate) fn keystream_block(&mut self) {
+        debug_assert!(
+            !self.exhausted,
+            "internally called keystream_block on an exhausted state!"
+        );
+
+        self.exhausted = self.streampos == u32::MAX;
+        self.state[3].0 = self.streampos;
+
+        let mut wstate = self.apply_rounds();
+
+        wstate[0] = wstate[0].wrapping_add(self.state[0]);
+        wstate[1] = wstate[1].wrapping_add(self.state[1]);
+        wstate[2] = wstate[2].wrapping_add(self.state[2]);
+        wstate[3] = wstate[3].wrapping_add(self.state[3]);
+
+        wstate[0].store_into_le(&mut self.keystreamblock[0..16]);
+        wstate[1].store_into_le(&mut self.keystreamblock[16..32]);
+        wstate[2].store_into_le(&mut self.keystreamblock[32..48]);
+        wstate[3].store_into_le(&mut self.keystreamblock[48..64]);
+
+        #[cfg(feature = "zeroize")]
+        wstate.iter_mut().zeroize();
+
+        if let Some(nextpos) = self.streampos.checked_add(1) {
+            self.streampos = nextpos;
         } else {
-            wr0.store_into_le(iter.next().unwrap());
-            wr3.store_into_le(iter.next().unwrap());
+            assert!(self.exhausted);
+            assert_eq!(self.streampos, u32::MAX);
         }
     }
-}
 
-/// XOR keystream into destination array using a temporary buffer for each keystream block.
-pub(crate) fn xor_keystream(
-    ctx: &mut ChaCha20,
-    initial_counter: u32,
-    tmp_block: &mut [u8],
-    bytes: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    debug_assert_eq!(tmp_block.len(), CHACHA_BLOCKSIZE);
-    if bytes.is_empty() {
-        return Err(UnknownCryptoError);
+    /// Given the current [`Self::position`], determine how many keystream
+    /// bytes can be generated from here on out. If [`Self::is_exhausted()`], then
+    /// this gives `0`.
+    pub fn keystream_remaining(&self) -> u64 {
+        debug_assert!((u32::MAX as u64 + 1) * (CHACHA_BLOCKSIZE as u64) < u64::MAX);
+        if self.is_exhausted() {
+            return 0;
+        }
+
+        let max: u64 = (u32::MAX as u64) + 1; // (0..=u32::MAX)
+        (max - (self.streampos as u64)) * CHACHA_BLOCKSIZE as u64
     }
 
-    for (ctr, out_block) in bytes.chunks_mut(CHACHA_BLOCKSIZE).enumerate() {
-        match initial_counter.checked_add(ctr as u32) {
-            Some(counter) => {
-                ctx.keystream_block(counter, tmp_block);
-                xor_slices!(tmp_block, out_block);
+    /// Set the position/counter of the [`ChaCha20`] state.
+    /// This is equivalent to seeking ahead in the keystream output generated,
+    /// for a given pair of [`SecretKey`] and [`Nonce`].
+    pub fn set_position(&mut self, blockctr: u32) {
+        self.streampos = blockctr;
+        self.state[3].0 = self.streampos;
+    }
+
+    /// Return the current position within the keystream.
+    /// This is what will be used when generating the next keystream block.
+    pub fn position(&self) -> u32 {
+        self.streampos
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// Produce keystream blocks, based on the [`ChaCha20::position()`], and XOR into `bytes`.
+    ///
+    /// # NOTE:
+    /// When explicitly generating keystream blocks, e.g. with a combination of [`ChaCha20::set_position()`],
+    /// and this one, no leftover handling is performed. If `bytes` is less than [`CHACHA_BLOCKSIZE`] or not
+    /// a multiple thereof, the leftover bytes are not saved. This function will always generate a keystream block
+    /// based on the current position and if `bytes` cannot hold all [`CHACHA_BLOCKSIZE`] bytes, then they are "forgotten".
+    ///
+    ///
+    /// # SECURITY:
+    /// If this returns [`UnknownCryptoError`], then not all `bytes` have been processed.
+    /// Take care to zero out the bytes if this contains sensitive information.
+    pub fn xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        if self.exhausted {
+            return Err(UnknownCryptoError);
+        }
+
+        // https://github.com/orion-rs/orion/issues/308 fix was to not copy
+        // plaintext into out-buffer. This new API means there's only one.
+        // Here `bytes` contain plaintext, so now it is user-respnsibility
+        // to ensure to zero out plaintext bytes if the function fails.
+
+        let mut parts = bytes.chunks_mut(CHACHA_BLOCKSIZE).peekable();
+        while let Some(block) = parts.next() {
+            self.keystream_block();
+            xor_slices(&self.keystreamblock, block);
+
+            // The only time we don't want to error on this check
+            // is when we have self.streampos == u32::MAX and there's
+            // at most CHACHA_BLOCKSIZE amount of bytes to process.
+            // self.exhausted will prevent this from happening more than once.
+            if parts.peek().is_some() {
+                self.next_producible()?;
             }
-            None => return Err(UnknownCryptoError),
         }
+
+        Ok(())
     }
-
-    Ok(())
-}
-
-/// In-place IETF ChaCha20 encryption as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub(crate) fn encrypt_in_place(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    initial_counter: u32,
-    bytes: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    if bytes.is_empty() {
-        return Err(UnknownCryptoError);
-    }
-
-    let mut ctx = ChaCha20::new(secret_key.unprotected_as_ref(), nonce.as_ref(), true)?;
-    let mut keystream_block = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-    xor_keystream(&mut ctx, initial_counter, keystream_block.as_mut(), bytes)
-}
-
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// IETF ChaCha20 encryption as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub fn encrypt(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    initial_counter: u32,
-    plaintext: &[u8],
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    if dst_out.len() < plaintext.len() {
-        return Err(UnknownCryptoError);
-    }
-    if plaintext.is_empty() {
-        return Err(UnknownCryptoError);
-    }
-
-    let mut ctx = ChaCha20::new(secret_key.unprotected_as_ref(), nonce.as_ref(), true)?;
-    let mut keystream_block = zeroize_wrap!([0u8; CHACHA_BLOCKSIZE]);
-
-    for (ctr, (p_block, c_block)) in plaintext
-        .chunks(CHACHA_BLOCKSIZE)
-        .zip(dst_out.chunks_mut(CHACHA_BLOCKSIZE))
-        .enumerate()
-    {
-        match initial_counter.checked_add(ctr as u32) {
-            Some(counter) => {
-                // See https://github.com/orion-rs/orion/issues/308
-                ctx.next_produceable()?;
-
-                ctx.keystream_block(counter, keystream_block.as_mut());
-                xor_slices!(p_block, keystream_block.as_mut());
-                c_block[..p_block.len()]
-                    .copy_from_slice(&keystream_block.as_ref()[..p_block.len()]);
-            }
-            None => return Err(UnknownCryptoError),
-        }
-    }
-
-    Ok(())
-}
-
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// IETF ChaCha20 decryption as specified in the [RFC 8439](https://tools.ietf.org/html/rfc8439).
-pub fn decrypt(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    initial_counter: u32,
-    ciphertext: &[u8],
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    encrypt(secret_key, nonce, initial_counter, ciphertext, dst_out)
-}
-
-/// HChaCha20 as specified in the [draft-RFC](https://github.com/bikeshedders/xchacha-rfc/blob/master).
-pub(super) fn hchacha20(
-    secret_key: &SecretKey,
-    nonce: &[u8],
-) -> Result<[u8; HCHACHA_OUTSIZE], UnknownCryptoError> {
-    let mut chacha_state = ChaCha20::new(secret_key.unprotected_as_ref(), nonce, false)?;
-    let mut keystream_block = [0u8; HCHACHA_OUTSIZE];
-    chacha_state.keystream_block(0, &mut keystream_block);
-
-    Ok(keystream_block)
 }
 
 // Testing public functions in the module.
 #[cfg(test)]
 mod public {
     use super::*;
+    use crate::test_framework::streamcipher_interface::*;
+
+    const ZERO_KEY: [u8; CHACHA_KEYSIZE] = [0u8; CHACHA_KEYSIZE];
+    const ZERO_IETF_NONCE: [u8; IETF_CHACHA_NONCESIZE] = [0u8; IETF_CHACHA_NONCESIZE];
+
+    #[test]
+    #[cfg(feature = "safe_api")]
+    // format! is only available with std
+    fn test_omitted_debug() {
+        let sk = SecretKey::generate().unwrap();
+        let n = Nonce::from(ZERO_IETF_NONCE);
+        let ctx = ChaCha20::new(&sk, &n);
+
+        let secret_key = format!("{:?}", &ctx.state);
+        let secret_export = format!("{:?}", &ctx.keystreamblock);
+
+        let test_debug_contents = format!("{:?}", &ctx);
+        assert!(!test_debug_contents.contains(&secret_key));
+        assert!(!test_debug_contents.contains(&secret_export));
+    }
+
+    #[test]
+    fn test_keystream_remaining() {
+        let sk = SecretKey::from(ZERO_KEY);
+        let nonce = Nonce::from(ZERO_IETF_NONCE);
+        let mut ctx = ChaCha20::new(&sk, &nonce);
+
+        ctx.set_position(0);
+        assert_eq!(ctx.position(), 0);
+        assert_eq!(
+            ctx.keystream_remaining(),
+            (CHACHA_BLOCKSIZE as u64) * 2u64.pow(32)
+        );
+
+        ctx.set_position(1);
+        assert_eq!(ctx.position(), 1);
+        assert_eq!(
+            ctx.keystream_remaining(),
+            crate::hazardous::aead::chacha20poly1305::P_MAX
+        );
+
+        ctx.set_position(u32::MAX);
+        assert_eq!(ctx.position(), u32::MAX);
+        assert_eq!(ctx.keystream_remaining(), 64);
+
+        // If we encrypt 1.5 block, we "forget" the rest. So this will return
+        // the amount as if we encrypted two full blocks.
+        let mut onehalf = [0u8; CHACHA_BLOCKSIZE + CHACHA_BLOCKSIZE / 2];
+        ctx.set_position(1);
+        ctx.xor_keystream_into(&mut onehalf).unwrap();
+        assert_eq!(ctx.position(), 3);
+        assert_eq!(
+            ctx.keystream_remaining(),
+            crate::hazardous::aead::chacha20poly1305::P_MAX - (CHACHA_BLOCKSIZE as u64 * 2)
+        );
+    }
 
     #[test]
     fn test_chacha20_key() {
@@ -467,110 +533,112 @@ mod public {
         PublicNewtype::test_serialization::<IETF_CHACHA_NONCESIZE, ChaCha20Nonce>();
     }
 
-    #[cfg(feature = "safe_api")]
-    #[test]
-    // See https://github.com/orion-rs/orion/issues/308
-    fn test_plaintext_left_in_dst_out() {
-        let k = SecretKey::generate().unwrap();
-        let n = Nonce::try_from(&[0u8; 12]).unwrap();
-        let ic: u32 = u32::MAX - 1;
+    impl TestableStreamCipher for ChaCha20 {
+        fn _new(sk: &[u8], n: &[u8]) -> Self {
+            Self::new(
+                &SecretKey::try_from(sk).unwrap(),
+                &Nonce::try_from(n).unwrap(),
+            )
+        }
 
-        let text = [b'x'; 128 + 4];
-        let mut dst_out = [0u8; 128 + 4];
+        #[cfg(test)]
+        #[cfg(feature = "safe_api")]
+        fn _random() -> Self {
+            use rand::RngExt;
+            let mut rng = rand::rng();
+            let rand_sk: bool = rng.random();
 
-        let _err = encrypt(&k, &n, ic, &text, &mut dst_out).unwrap_err();
+            let (sk, n) = if rand_sk {
+                (SecretKey::generate().unwrap(), Nonce::from(ZERO_IETF_NONCE))
+            } else {
+                // only implemented for testing purposes.
+                let mut arr = ZERO_IETF_NONCE;
+                rng.fill(&mut arr);
+                (SecretKey::from(ZERO_KEY), Nonce::from(arr))
+            };
 
-        assert_ne!(&[b'x'; 4], &dst_out[dst_out.len() - 4..]);
+            Self::_new(sk.unprotected_as_ref(), n.as_ref())
+        }
+
+        fn _next_producible(&self) -> Result<(), UnknownCryptoError> {
+            self.next_producible()
+        }
+
+        fn _keystream_remaining(&self) -> u64 {
+            self.keystream_remaining()
+        }
+
+        fn _set_position(&mut self, blockctr: u32) {
+            self.set_position(blockctr);
+        }
+
+        fn _is_exhausted(&self) -> bool {
+            self.is_exhausted()
+        }
+
+        fn _position(&self) -> u32 {
+            self.position()
+        }
+
+        fn _xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError> {
+            self.xor_keystream_into(bytes)
+        }
     }
 
     #[test]
-    fn test_xor_keystream_err_initial_ctr_overflow() {
-        let sk = SecretKey::try_from(&[0u8; 32]).unwrap();
-        let nonce = Nonce::try_from(&[0u8; 12]).unwrap();
-        let mut chacha_state =
-            ChaCha20::new(sk.unprotected_as_ref(), nonce.as_ref(), true).unwrap();
-
-        let mut tmp_block = [0u8; CHACHA_BLOCKSIZE];
-        let mut bytes = [12u8; CHACHA_BLOCKSIZE * 2];
-        // Should return error on processing of second block.
-        assert!(xor_keystream(&mut chacha_state, u32::MAX, &mut tmp_block, &mut bytes).is_err());
+    fn test_streamcipher() {
+        StreamcipherTester::<ChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
+            &ZERO_KEY,
+            &ZERO_IETF_NONCE,
+            None,
+            None,
+        );
     }
 
+    #[quickcheck]
     #[cfg(feature = "safe_api")]
-    mod test_encrypt_decrypt {
-        use super::*;
-        use crate::test_framework::streamcipher_interface::*;
+    fn prop_streamcipher_interface(input: Vec<u8>) -> bool {
+        let sk = SecretKey::generate().unwrap();
+        let n = Nonce::from(ZERO_IETF_NONCE);
+        StreamcipherTester::<ChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
+            sk.unprotected_as_ref(),
+            n.as_ref(),
+            Some(&input),
+            None,
+        );
 
-        impl TestingRandom for SecretKey {
-            fn gen_new() -> Self {
-                Self::generate().unwrap()
-            }
-        }
-
-        impl TestingRandom for Nonce {
-            fn gen_new() -> Self {
-                let mut n = [0u8; IETF_CHACHA_NONCESIZE];
-                crate::util::secure_rand_bytes(&mut n).unwrap();
-                Self::try_from(&n).unwrap()
-            }
-        }
-
-        #[quickcheck]
-        fn prop_streamcipher_interface(input: Vec<u8>, counter: u32) -> bool {
-            let secret_key = SecretKey::generate().unwrap();
-            let nonce = Nonce::try_from(&[0u8; IETF_CHACHA_NONCESIZE]).unwrap();
-            StreamCipherTestRunner(encrypt, decrypt, secret_key, nonce, counter, &input, None);
-            test_diff_params_diff_output(&encrypt, &decrypt);
-
-            true
-        }
+        true
     }
 
     #[cfg(any(feature = "safe_api", feature = "alloc"))]
-    // hex crate uses Vec<u8>, so we need std.
     mod test_hchacha20 {
         use super::*;
 
-        use hex::decode;
-
-        #[test]
-        fn test_nonce_length() {
-            assert!(hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[0u8; 16],).is_ok());
-            assert!(hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[0u8; 17],).is_err());
-            assert!(hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[0u8; 15],).is_err());
-            assert!(hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[0u8; 0],).is_err());
-        }
-
         #[test]
         fn test_diff_keys_diff_output() {
-            let keystream1 =
-                hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[0u8; 16]).unwrap();
-
-            let keystream2 =
-                hchacha20(&SecretKey::try_from(&[1u8; 32]).unwrap(), &[0u8; 16]).unwrap();
+            let keystream1 = ChaCha20::hchacha(&SecretKey::from(ZERO_KEY), &[0u8; 16]);
+            let keystream2 = ChaCha20::hchacha(&SecretKey::from([1u8; CHACHA_KEYSIZE]), &[0u8; 16]);
 
             assert_ne!(keystream1, keystream2);
         }
 
         #[test]
         fn test_diff_nonce_diff_output() {
-            let keystream1 =
-                hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[0u8; 16]).unwrap();
-
-            let keystream2 =
-                hchacha20(&SecretKey::try_from(&[0u8; 32]).unwrap(), &[1u8; 16]).unwrap();
+            let sk = SecretKey::from(ZERO_KEY);
+            let keystream1 = ChaCha20::hchacha(&sk, &[0u8; 16]);
+            let keystream2 = ChaCha20::hchacha(&sk, &[1u8; 16]);
 
             assert_ne!(keystream1, keystream2);
         }
 
         pub fn hchacha_test_runner(key: &str, nonce: &str, output_expected: &str) {
-            let actual: [u8; 32] = hchacha20(
-                &SecretKey::try_from(&decode(key).unwrap()).unwrap(),
-                &decode(nonce).unwrap(),
-            )
-            .unwrap();
+            let expected: [u8; HCHACHA_OUTSIZE] =
+                hex::decode(output_expected).unwrap().try_into().unwrap();
+            let sk = SecretKey::try_from(&hex::decode(key).unwrap()).unwrap();
+            let n: [u8; HCHACHA_NONCESIZE] = hex::decode(nonce).unwrap().try_into().unwrap();
 
-            assert_eq!(&actual, &decode(output_expected).unwrap()[..]);
+            let actual: [u8; HCHACHA_OUTSIZE] = ChaCha20::hchacha(&sk, &n);
+            assert_eq!(actual, expected);
         }
 
         // Testing against Monocypher-generated test vectors
@@ -985,76 +1053,17 @@ mod public {
 mod private {
     use super::*;
 
-    mod test_init_state {
+    const ZERO_KEY: [u8; CHACHA_KEYSIZE] = [0u8; CHACHA_KEYSIZE];
+    const ZERO_IETF_NONCE: [u8; IETF_CHACHA_NONCESIZE] = [0u8; IETF_CHACHA_NONCESIZE];
+
+    mod test_xor_keystream_into {
         use super::*;
 
         #[test]
-        fn test_nonce_length() {
-            assert!(ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; 15], true).is_err());
-            assert!(ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; 10], true).is_err());
-            assert!(
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; IETF_CHACHA_NONCESIZE], true).is_ok()
-            );
-
-            assert!(ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; 15], false).is_err());
-            assert!(ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; 17], false).is_err());
-            assert!(
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; HCHACHA_NONCESIZE], false).is_ok()
-            );
-        }
-
-        #[quickcheck]
-        #[cfg(feature = "safe_api")]
-        fn prop_test_nonce_length_ietf(nonce: Vec<u8>) -> bool {
-            if nonce.len() == IETF_CHACHA_NONCESIZE {
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &nonce[..], true).is_ok()
-            } else {
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &nonce[..], true).is_err()
-            }
-        }
-
-        #[quickcheck]
-        #[cfg(feature = "safe_api")]
-        // Always fail to initialize state while the nonce is not
-        // the correct length. If it is correct length, never panic.
-        fn prop_test_nonce_length_hchacha(nonce: Vec<u8>) -> bool {
-            if nonce.len() == HCHACHA_NONCESIZE {
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &nonce, false).is_ok()
-            } else {
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &nonce, false).is_err()
-            }
-        }
-    }
-
-    mod test_encrypt_in_place {
-        use super::*;
-
-        #[test]
-        #[should_panic]
-        #[cfg(debug_assertions)]
-        fn test_xor_keystream_err_bad_tmp() {
-            let mut ctx =
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; IETF_CHACHA_NONCESIZE], true).unwrap();
-            let mut tmp = [0u8; CHACHA_BLOCKSIZE - 1];
-            let mut out = [0u8; CHACHA_BLOCKSIZE];
-            xor_keystream(&mut ctx, 0, &mut tmp, &mut out).unwrap();
-        }
-
-        #[test]
-        fn test_xor_keystream_err_empty_input() {
-            let mut ctx =
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; IETF_CHACHA_NONCESIZE], true).unwrap();
-            let mut tmp = [0u8; CHACHA_BLOCKSIZE];
+        fn test_xor_keystream_ok_empty_input() {
+            let mut ctx = ChaCha20::new(&SecretKey::from(ZERO_KEY), &Nonce::from(ZERO_IETF_NONCE));
             let mut out = [0u8; 0];
-            assert!(xor_keystream(&mut ctx, 0, &mut tmp, &mut out).is_err());
-        }
-
-        #[test]
-        fn test_enc_in_place_err_empty_input() {
-            let n = Nonce::from([0u8; IETF_CHACHA_NONCESIZE]);
-            let sk = SecretKey::from([0u8; CHACHA_KEYSIZE]);
-            let mut out = [0u8; 0];
-            assert!(encrypt_in_place(&sk, &n, 0, &mut out).is_err());
+            assert!(ctx.xor_keystream_into(&mut out).is_ok());
         }
     }
 
@@ -1062,50 +1071,7 @@ mod private {
         use super::*;
 
         #[test]
-        fn test_xor_keystream_block_ignore_counter_when_hchacha() {
-            let mut chacha_state_hchacha =
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; HCHACHA_NONCESIZE], false).unwrap();
-
-            let mut hchacha_keystream_block_zero = [0u8; HCHACHA_OUTSIZE];
-            let mut hchacha_keystream_block_max = [0u8; HCHACHA_OUTSIZE];
-
-            chacha_state_hchacha.keystream_block(0, &mut hchacha_keystream_block_zero);
-            chacha_state_hchacha.keystream_block(u32::MAX, &mut hchacha_keystream_block_max);
-
-            assert_eq!(hchacha_keystream_block_zero, hchacha_keystream_block_max);
-        }
-
-        #[cfg(debug_assertions)]
-        #[test]
-        #[should_panic]
-        fn test_xor_keystream_block_invalid_blocksize_ietf() {
-            let mut chacha_state_ietf =
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; IETF_CHACHA_NONCESIZE], true).unwrap();
-
-            let mut ietf_keystream_block = [0u8; CHACHA_BLOCKSIZE];
-            let mut hchacha_keystream_block = [0u8; HCHACHA_OUTSIZE];
-
-            chacha_state_ietf.keystream_block(0, &mut ietf_keystream_block);
-            chacha_state_ietf.keystream_block(0, &mut hchacha_keystream_block);
-        }
-
-        #[cfg(debug_assertions)]
-        #[test]
-        #[should_panic]
-        fn test_xor_keystream_block_invalid_blocksize_hchacha() {
-            let mut chacha_state_hchacha =
-                ChaCha20::new(&[0u8; CHACHA_KEYSIZE], &[0u8; HCHACHA_NONCESIZE], false).unwrap();
-
-            let mut ietf_keystream_block = [0u8; CHACHA_BLOCKSIZE];
-            let mut hchacha_keystream_block = [0u8; HCHACHA_OUTSIZE];
-
-            chacha_state_hchacha.keystream_block(0, &mut hchacha_keystream_block);
-            chacha_state_hchacha.keystream_block(0, &mut ietf_keystream_block);
-        }
-
-        #[test]
-        #[should_panic]
-        fn test_xor_keystream_panic_on_too_much_keystream_data_ietf() {
+        fn test_xor_keystream_err_on_too_much_keystream_data_ietf() {
             let mut chacha_state_ietf = ChaCha20 {
                 state: [
                     U32x4(0, 0, 0, 0),
@@ -1113,40 +1079,38 @@ mod private {
                     U32x4(0, 0, 0, 0),
                     U32x4(0, 0, 0, 0),
                 ],
-                internal_counter: (u32::MAX - 128),
-                is_ietf: true,
+                keystreamblock: [0u8; CHACHA_BLOCKSIZE],
+                streampos: (u32::MAX - 128),
+                exhausted: false,
             };
 
-            let mut keystream_block = [0u8; CHACHA_BLOCKSIZE];
+            // xor_keystream_into() logic is tested with: StreamcipherTester::last_keystream_block_exhausts().
 
-            for amount in 0..(128 + 1) {
-                chacha_state_ietf.keystream_block(amount, &mut keystream_block);
+            assert_eq!(chacha_state_ietf.position(), u32::MAX - 128);
+            assert_eq!(
+                chacha_state_ietf.keystream_remaining(),
+                (u32::MAX - chacha_state_ietf.position() + 1) as u64 * CHACHA_BLOCKSIZE as u64
+            );
+
+            for block_n in 0..=128 {
+                if block_n == 128 {
+                    assert!(!chacha_state_ietf.is_exhausted());
+                    assert_eq!(chacha_state_ietf.position(), u32::MAX);
+
+                    chacha_state_ietf.keystream_block();
+
+                    assert!(chacha_state_ietf.is_exhausted());
+                    assert_eq!(chacha_state_ietf.position(), u32::MAX);
+                } else {
+                    chacha_state_ietf.keystream_block();
+                }
             }
         }
 
         #[test]
+        #[cfg(debug_assertions)]
         #[should_panic]
-        fn test_xor_keystream_panic_on_too_much_keystream_data_hchacha() {
-            let mut chacha_state_ietf = ChaCha20 {
-                state: [
-                    U32x4(0, 0, 0, 0),
-                    U32x4(0, 0, 0, 0),
-                    U32x4(0, 0, 0, 0),
-                    U32x4(0, 0, 0, 0),
-                ],
-                internal_counter: (u32::MAX - 128),
-                is_ietf: false,
-            };
-
-            let mut keystream_block = [0u8; HCHACHA_OUTSIZE];
-
-            for _ in 0..(128 + 1) {
-                chacha_state_ietf.keystream_block(0, &mut keystream_block);
-            }
-        }
-
-        #[test]
-        fn test_error_if_internal_counter_would_overflow() {
+        fn test_panic_debug_calling_keystream_block_on_exhausted() {
             let mut chacha_state = ChaCha20 {
                 state: [
                     U32x4(0, 0, 0, 0),
@@ -1154,15 +1118,17 @@ mod private {
                     U32x4(0, 0, 0, 0),
                     U32x4(0, 0, 0, 0),
                 ],
-                internal_counter: (u32::MAX - 2),
-                is_ietf: false,
+                keystreamblock: [0u8; CHACHA_BLOCKSIZE],
+                streampos: (u32::MAX - 2),
+                exhausted: false,
             };
 
-            assert!(chacha_state.next_produceable().is_ok());
-            chacha_state.internal_counter += 1;
-            assert!(chacha_state.next_produceable().is_ok());
-            chacha_state.internal_counter += 1;
-            assert!(chacha_state.next_produceable().is_err());
+            chacha_state.keystream_block();
+            chacha_state.keystream_block();
+            chacha_state.keystream_block();
+
+            // debug_assert! fails:
+            chacha_state.keystream_block();
         }
     }
 }
@@ -1180,10 +1146,6 @@ mod test_vectors {
         }
     }
 
-    // Convenience function for testing.
-    fn init(key: &[u8], nonce: &[u8]) -> Result<ChaCha20, UnknownCryptoError> {
-        ChaCha20::new(key, nonce, true)
-    }
     #[test]
     fn rfc8439_chacha20_block_results() {
         let key = [
@@ -1209,15 +1171,12 @@ mod test_vectors {
             U32x4(0x00000001, 0x09000000, 0x4a000000, 0x00000000),
         ];
         // Test initial key-setup
-        let mut state = init(&key, &nonce).unwrap();
-        // Set block counter
-        state.state[3].0 = 1;
-        assert!(state.state[..] == expected_init[..]);
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
+        state.set_position(1);
+        assert_eq!(state.state, expected_init);
 
-        let mut kb = [0u8; 64];
-        state.keystream_block(1, &mut kb);
-
-        assert_eq!(kb[..], expected[..]);
+        state.keystream_block();
+        assert_eq!(state.keystreamblock, expected);
     }
 
     #[test]
@@ -1238,11 +1197,10 @@ mod test_vectors {
             0xc3, 0x87, 0xb6, 0x69, 0xb2, 0xee, 0x65, 0x86,
         ];
 
-        let mut state = init(&key, &nonce).unwrap();
-        let mut kb = [0u8; 64];
-        state.keystream_block(0, &mut kb);
-
-        assert_eq!(kb[..], expected[..]);
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
+        state.set_position(0);
+        state.keystream_block();
+        assert_eq!(state.keystreamblock, expected);
     }
 
     #[test]
@@ -1263,11 +1221,10 @@ mod test_vectors {
             0xac, 0xe1, 0x0a, 0x1f, 0x4b, 0x79, 0x4d, 0x6f,
         ];
 
-        let mut state = init(&key, &nonce).unwrap();
-        let mut kb = [0u8; 64];
-        state.keystream_block(1, &mut kb);
-
-        assert_eq!(kb[..], expected[..]);
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
+        state.set_position(1);
+        state.keystream_block();
+        assert_eq!(state.keystreamblock, expected);
     }
 
     #[test]
@@ -1288,11 +1245,10 @@ mod test_vectors {
             0xa6, 0x4a, 0xdd, 0xeb, 0x00, 0x6c, 0x13, 0xa0,
         ];
 
-        let mut state = init(&key, &nonce).unwrap();
-        let mut kb = [0u8; 64];
-        state.keystream_block(1, &mut kb);
-
-        assert_eq!(kb[..], expected[..]);
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
+        state.set_position(1);
+        state.keystream_block();
+        assert_eq!(state.keystreamblock, expected);
     }
 
     #[test]
@@ -1313,11 +1269,10 @@ mod test_vectors {
             0x73, 0x74, 0xf4, 0x87, 0x2e, 0x99, 0xf0, 0x96,
         ];
 
-        let mut state = init(&key, &nonce).unwrap();
-        let mut kb = [0u8; 64];
-        state.keystream_block(2, &mut kb);
-
-        assert_eq!(kb[..], expected[..]);
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
+        state.set_position(2);
+        state.keystream_block();
+        assert_eq!(state.keystreamblock, expected);
     }
 
     #[test]
@@ -1338,11 +1293,10 @@ mod test_vectors {
             0xfa, 0x19, 0x8a, 0x39, 0x53, 0x1b, 0xed, 0x6d,
         ];
 
-        let mut state = init(&key, &nonce).unwrap();
-        let mut kb = [0u8; 64];
-        state.keystream_block(0, &mut kb);
-
-        assert_eq!(kb[..], expected[..]);
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
+        state.set_position(0);
+        state.keystream_block();
+        assert_eq!(state.keystreamblock, expected);
     }
 
     #[test]
@@ -1383,13 +1337,19 @@ mod test_vectors {
             0xf3, 0x63,
         ];
 
-        let mut state = init(&key, &nonce).unwrap();
+        let mut state = ChaCha20::new(&SecretKey::from(key), &Nonce::from(nonce));
         let mut actual_keystream = [0u8; 128];
 
-        state.keystream_block(1, &mut actual_keystream[..64]);
+        state.set_position(1);
+        state
+            .xor_keystream_into(&mut actual_keystream[..64])
+            .unwrap();
         assert!(first_state == state.state);
 
-        state.keystream_block(2, &mut actual_keystream[64..]);
+        state.set_position(2);
+        state
+            .xor_keystream_into(&mut actual_keystream[64..])
+            .unwrap();
         assert!(second_state == state.state);
 
         assert_eq!(

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -287,10 +287,9 @@ impl ChaCha20 {
 
     /// Check that we can produce one more keystream block, given the current state.
     ///
-    /// Return error if advancing the internal state position by one would overflow [`u32::MAX`],
-    /// or the keystream has been exhausted (see [`Self::is_exhausted`]).
+    /// Return error if [`Self::is_exhausted()`].
     pub fn next_producible(&self) -> Result<(), UnknownCryptoError> {
-        if self.streampos.checked_add(1).is_none() || self.exhausted {
+        if self.exhausted {
             Err(UnknownCryptoError)
         } else {
             Ok(())
@@ -469,6 +468,40 @@ mod public {
         let test_debug_contents = format!("{:?}", &ctx);
         assert!(!test_debug_contents.contains(&secret_key));
         assert!(!test_debug_contents.contains(&secret_export));
+    }
+
+    #[test]
+    fn test_xor_keystream_last_two_full_blocks() {
+        let sk = SecretKey::from(ZERO_KEY);
+        let nonce = Nonce::from(ZERO_IETF_NONCE);
+
+        // Use u32::MAX to fill the last half block
+        let mut ctx = ChaCha20::new(&sk, &nonce);
+        ctx.set_position(u32::MAX - 1);
+        let mut twoblocks_min = [0u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)];
+        assert!(ctx.xor_keystream_into(&mut twoblocks_min).is_ok());
+        assert!(ctx.is_exhausted());
+        assert_eq!(ctx.keystream_remaining(), 0);
+
+        // Use u32::MAX to fill the full last blocks
+        let mut ctx = ChaCha20::new(&sk, &nonce);
+        ctx.set_position(u32::MAX - 1);
+        let mut twoblocks_mid = [0u8; CHACHA_BLOCKSIZE * 2];
+        assert!(ctx.xor_keystream_into(&mut twoblocks_mid).is_ok());
+        assert!(ctx.is_exhausted());
+        assert_eq!(ctx.keystream_remaining(), 0);
+
+        // ERR: Do not move past two full blocks
+        let mut ctx = ChaCha20::new(&sk, &nonce);
+        ctx.set_position(u32::MAX - 1);
+        let mut twoblocks_max = [0u8; (CHACHA_BLOCKSIZE * 2) + 1];
+        assert!(ctx.xor_keystream_into(&mut twoblocks_max).is_err());
+        assert!(ctx.is_exhausted());
+        assert_eq!(ctx.keystream_remaining(), 0);
+
+        assert_eq!(&twoblocks_min, &twoblocks_mid[..twoblocks_min.len()]);
+        assert_eq!(&twoblocks_mid, &twoblocks_max[..twoblocks_mid.len()]);
+        assert_eq!(twoblocks_max[twoblocks_max.len() - 1], 0);
     }
 
     #[test]

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -471,40 +471,6 @@ mod public {
     }
 
     #[test]
-    fn test_xor_keystream_last_two_full_blocks() {
-        let sk = SecretKey::from(ZERO_KEY);
-        let nonce = Nonce::from(ZERO_IETF_NONCE);
-
-        // Use u32::MAX to fill the last half block
-        let mut ctx = ChaCha20::new(&sk, &nonce);
-        ctx.set_position(u32::MAX - 1);
-        let mut twoblocks_min = [0u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)];
-        assert!(ctx.xor_keystream_into(&mut twoblocks_min).is_ok());
-        assert!(ctx.is_exhausted());
-        assert_eq!(ctx.keystream_remaining(), 0);
-
-        // Use u32::MAX to fill the full last blocks
-        let mut ctx = ChaCha20::new(&sk, &nonce);
-        ctx.set_position(u32::MAX - 1);
-        let mut twoblocks_mid = [0u8; CHACHA_BLOCKSIZE * 2];
-        assert!(ctx.xor_keystream_into(&mut twoblocks_mid).is_ok());
-        assert!(ctx.is_exhausted());
-        assert_eq!(ctx.keystream_remaining(), 0);
-
-        // ERR: Do not move past two full blocks
-        let mut ctx = ChaCha20::new(&sk, &nonce);
-        ctx.set_position(u32::MAX - 1);
-        let mut twoblocks_max = [0u8; (CHACHA_BLOCKSIZE * 2) + 1];
-        assert!(ctx.xor_keystream_into(&mut twoblocks_max).is_err());
-        assert!(ctx.is_exhausted());
-        assert_eq!(ctx.keystream_remaining(), 0);
-
-        assert_eq!(&twoblocks_min, &twoblocks_mid[..twoblocks_min.len()]);
-        assert_eq!(&twoblocks_mid, &twoblocks_max[..twoblocks_mid.len()]);
-        assert_eq!(twoblocks_max[twoblocks_max.len() - 1], 0);
-    }
-
-    #[test]
     fn test_keystream_remaining() {
         let sk = SecretKey::from(ZERO_KEY);
         let nonce = Nonce::from(ZERO_IETF_NONCE);

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -41,6 +41,7 @@
 //!   moves [`ChaCha20`] into an exhausted state, which is non-resettable. In this case, the key/nonce pair
 //!   has generated all possible keystream bytes and is thus not safe to use further.
 //!   This can be checked with [`ChaCha20::is_exhausted()`].
+//! - If [`ChaCha20::set_byte_position()`] is called with a `pos` that is equal to or greater than [`MAX_KEYSTREAM_BYTES`].
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
@@ -91,6 +92,7 @@
 //! [`ChaCha20::position()`]: chacha20::ChaCha20::position()
 //! [`ChaCha20::is_exhausted()`]: chacha20::ChaCha20::is_exhausted()
 //! [`ChaCha20::next_producible()`]: chacha20::ChaCha20::next_producible()
+//! [`ChaCha20::set_byte_position()`]: chacha20::ChaCha20::set_byte_position()
 
 //! [RFC]: https://tools.ietf.org/html/rfc8439
 use crate::GenerateSecret;
@@ -374,8 +376,8 @@ impl ChaCha20 {
         if let Some(nextpos) = self.streampos.checked_add(1) {
             self.streampos = nextpos;
         } else {
-            assert!(self.exhausted);
-            assert_eq!(self.streampos, u32::MAX);
+            debug_assert!(self.exhausted);
+            debug_assert_eq!(self.streampos, u32::MAX);
         }
     }
 
@@ -453,6 +455,10 @@ impl ChaCha20 {
 
     /// Get the current position/counter of the [`ChaCha20`] state, as a byte-index.
     pub fn byte_position(&mut self) -> u64 {
+        if self.exhausted && self.blockoffset == 0 {
+            return MAX_KEYSTREAM_BYTES;
+        }
+
         if self.blockoffset == 0 {
             return self.streampos as u64 * CHACHA_BLOCKSIZE as u64;
         }

--- a/src/hazardous/stream/chacha20.rs
+++ b/src/hazardous/stream/chacha20.rs
@@ -116,6 +116,8 @@ pub const CHACHA_BLOCKSIZE: usize = 64;
 const HCHACHA_OUTSIZE: usize = 32;
 /// The nonce size for HChaCha20.
 pub(crate) const HCHACHA_NONCESIZE: usize = 16;
+/// Maximum amount of keystream bytes that can be generated for a single key/nonce pair.
+pub const MAX_KEYSTREAM_BYTES: u64 = (u32::MAX as u64 + 1) * CHACHA_BLOCKSIZE as u64;
 
 #[derive(Debug)]
 /// Marker type for ChaCha20 key. See [`SecretKey`] type for convenience.
@@ -205,6 +207,7 @@ macro_rules! DOUBLE_ROUND {
 pub struct ChaCha20 {
     state: [U32x4; 4],
     pub(crate) keystreamblock: [u8; CHACHA_BLOCKSIZE],
+    blockoffset: u8,
     streampos: u32,
     /// Flag to track if the final block counter has been used.
     /// If we didn't track, we could end up writing the same keystream
@@ -221,8 +224,9 @@ impl Debug for ChaCha20 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "{} state: {{***OMITTED***}}, keystreamblock: {{***OMITTED***}}, streampos: {:?}, exhausted: {:?}",
+            "{} state: {{***OMITTED***}}, keystreamblock: {{***OMITTED***}}, blockoffset: {:?}, streampos: {:?}, exhausted: {:?}",
             stringify!(ChaCha20),
+            self.blockoffset,
             self.streampos,
             self.exhausted,
         )
@@ -275,6 +279,7 @@ impl ChaCha20 {
         Self {
             state: [r0, r1, r2, r3],
             keystreamblock: [0u8; CHACHA_BLOCKSIZE],
+            blockoffset: 0,
             streampos: 0,
             exhausted: false,
         }
@@ -374,42 +379,93 @@ impl ChaCha20 {
         }
     }
 
-    /// Given the current [`Self::position`], determine how many keystream
+    /// Given the current [`Self::byte_position`], determine how many keystream
     /// bytes can be generated from here on out. If [`Self::is_exhausted()`], then
-    /// this gives `0`.
+    /// this gives `0` if no leftover.
     pub fn keystream_remaining(&self) -> u64 {
         debug_assert!((u32::MAX as u64 + 1) * (CHACHA_BLOCKSIZE as u64) < u64::MAX);
+        let leftover: u64 = if self.blockoffset == 0 {
+            0
+        } else {
+            (CHACHA_BLOCKSIZE - self.blockoffset as usize) as u64
+        };
+
+        // If the keystream is exhausted, the only possible keystream
+        // left is `leftover`.
         if self.is_exhausted() {
-            return 0;
+            return leftover;
         }
 
+        // In case there is any leftover, then we have generated
+        // keystream block exactly at streampos, which has then
+        // subsequently been bumped in keystream_block(), so
+        // leftover is the bytes from streampos-1.
         let max: u64 = (u32::MAX as u64) + 1; // (0..=u32::MAX)
-        (max - (self.streampos as u64)) * CHACHA_BLOCKSIZE as u64
+        let remblocks: u64 = max - (self.streampos as u64);
+        let rembytes: u64 = remblocks * CHACHA_BLOCKSIZE as u64;
+
+        rembytes + leftover
     }
 
-    /// Set the position/counter of the [`ChaCha20`] state.
+    /// Set the position/counter of the [`ChaCha20`] state, to a specific block.
+    ///
+    /// # NOTE:
+    /// This resets the internal offset tracker, which keeps track of unused
+    /// but already generated keystream bytes, for the [`Self::position()`]
+    /// prior to calling this function. To set position in terms of specific
+    /// bytes across the entire keystream, use
+    ///
     /// This is equivalent to seeking ahead in the keystream output generated,
-    /// for a given pair of [`SecretKey`] and [`Nonce`].
+    /// on a per-block ([`CHACHA_BLOCKSIZE`]) basis.
     pub fn set_position(&mut self, blockctr: u32) {
         self.streampos = blockctr;
+        self.blockoffset = 0;
         self.state[3].0 = self.streampos;
     }
 
-    /// Return the current position within the keystream.
-    /// This is what will be used when generating the next keystream block.
+    /// Set the byte position within the [`ChaCha20`] state. This will set the correct
+    /// state block counter internally and any offset if needed.
+    pub fn set_byte_position(&mut self, pos: u64) -> Result<(), UnknownCryptoError> {
+        if pos >= MAX_KEYSTREAM_BYTES {
+            return Err(UnknownCryptoError);
+        }
+
+        let block = pos / CHACHA_BLOCKSIZE as u64;
+        debug_assert!((0..=u32::MAX).contains(&(block as u32)));
+        let offset = pos % CHACHA_BLOCKSIZE as u64;
+        debug_assert!((0..=CHACHA_BLOCKSIZE).contains(&(offset as usize)));
+        self.set_position(block as u32);
+
+        if offset > 0 {
+            self.next_producible()?;
+
+            self.keystream_block();
+            self.blockoffset = offset as u8;
+        }
+
+        Ok(())
+    }
+
+    /// Get the current position/counter of the [`ChaCha20`] state, as a block.
     pub fn position(&self) -> u32 {
         self.streampos
     }
 
+    /// Get the current position/counter of the [`ChaCha20`] state, as a byte-index.
+    pub fn byte_position(&mut self) -> u64 {
+        if self.blockoffset == 0 {
+            return self.streampos as u64 * CHACHA_BLOCKSIZE as u64;
+        }
+
+        if self.exhausted {
+            return self.streampos as u64 * CHACHA_BLOCKSIZE as u64 + self.blockoffset as u64;
+        }
+
+        (self.streampos - 1) as u64 * CHACHA_BLOCKSIZE as u64 + self.blockoffset as u64
+    }
+
     #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-    /// Produce keystream blocks, based on the [`ChaCha20::position()`], and XOR into `bytes`.
-    ///
-    /// # NOTE:
-    /// When explicitly generating keystream blocks, e.g. with a combination of [`ChaCha20::set_position()`],
-    /// and this one, no leftover handling is performed. If `bytes` is less than [`CHACHA_BLOCKSIZE`] or not
-    /// a multiple thereof, the leftover bytes are not saved. This function will always generate a keystream block
-    /// based on the current position and if `bytes` cannot hold all [`CHACHA_BLOCKSIZE`] bytes, then they are "forgotten".
-    ///
+    /// Produce keystream blocks, based on the [`ChaCha20::byte_position()`], and XOR into `bytes`.
     ///
     /// # SECURITY:
     /// If this returns [`UnknownCryptoError`], then not all `bytes` have been processed.
@@ -418,27 +474,50 @@ impl ChaCha20 {
         if bytes.is_empty() {
             return Ok(());
         }
-        if self.exhausted {
-            return Err(UnknownCryptoError);
-        }
 
         // https://github.com/orion-rs/orion/issues/308 fix was to not copy
-        // plaintext into out-buffer. This new API means there's only one.
+        // plaintext into out-buffer. This new API means there's only one buffer.
         // Here `bytes` contain plaintext, so now it is user-respnsibility
         // to ensure to zero out plaintext bytes if the function fails.
 
-        let mut parts = bytes.chunks_mut(CHACHA_BLOCKSIZE).peekable();
-        while let Some(block) = parts.next() {
-            self.keystream_block();
-            xor_slices(&self.keystreamblock, block);
+        let mut bytes = bytes;
+        // blockoffset should never reach CHACHA_BLOCKSIZE exactly, as this indicates
+        // the entire keystream has been consumed, a new one is generated and blockoffset
+        // it reset to 0.
+        debug_assert!((0..CHACHA_BLOCKSIZE).contains(&(self.blockoffset as usize)));
 
-            // The only time we don't want to error on this check
-            // is when we have self.streampos == u32::MAX and there's
-            // at most CHACHA_BLOCKSIZE amount of bytes to process.
-            // self.exhausted will prevent this from happening more than once.
-            if parts.peek().is_some() {
-                self.next_producible()?;
-            }
+        if self.blockoffset > 0 {
+            // SECURITY: This is the only time we don't check for self.exhausted/self.next_producible().
+            // If the keystream is exhausted, but we etner this branch, it means we have unused keystream
+            // leftover. This unused rem is safe to use. This function should only ever execute once after
+            // self.exhausted == true.
+            let offset = self.blockoffset as usize;
+            let want = core::cmp::min(CHACHA_BLOCKSIZE - offset, bytes.len());
+            xor_slices(
+                &self.keystreamblock[offset..offset + want],
+                &mut bytes[..want],
+            );
+
+            bytes = &mut bytes[want..];
+            self.blockoffset = ((offset + want) & (CHACHA_BLOCKSIZE - 1)) as u8;
+        }
+
+        while bytes.len() >= CHACHA_BLOCKSIZE {
+            self.next_producible()?;
+
+            self.keystream_block();
+            xor_slices(&self.keystreamblock, bytes);
+            bytes = &mut bytes[CHACHA_BLOCKSIZE..];
+        }
+
+        if !bytes.is_empty() {
+            debug_assert!(bytes.len() < CHACHA_BLOCKSIZE);
+            self.next_producible()?;
+
+            self.keystream_block();
+            let offset = bytes.len();
+            xor_slices(&self.keystreamblock[..offset], bytes);
+            self.blockoffset = offset as u8;
         }
 
         Ok(())
@@ -502,7 +581,7 @@ mod public {
         assert_eq!(ctx.position(), 3);
         assert_eq!(
             ctx.keystream_remaining(),
-            crate::hazardous::aead::chacha20poly1305::P_MAX - (CHACHA_BLOCKSIZE as u64 * 2)
+            MAX_KEYSTREAM_BYTES - (CHACHA_BLOCKSIZE * 2 + CHACHA_BLOCKSIZE / 2) as u64
         );
     }
 
@@ -582,16 +661,25 @@ mod public {
         fn _xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError> {
             self.xor_keystream_into(bytes)
         }
+
+        fn _set_byte_position(&mut self, pos: u64) -> Result<(), UnknownCryptoError> {
+            self.set_byte_position(pos)
+        }
+
+        fn _byte_position(&mut self) -> u64 {
+            self.byte_position()
+        }
+
+        const MAX_KEYSTREAM_BYTES: u64 = MAX_KEYSTREAM_BYTES;
     }
 
     #[test]
     fn test_streamcipher() {
-        StreamcipherTester::<ChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
-            &ZERO_KEY,
-            &ZERO_IETF_NONCE,
-            None,
-            None,
-        );
+        StreamcipherTester::<ChaCha20>::run_tests::<
+            CHACHA_BLOCKSIZE,
+            { u32::MAX },
+            MAX_KEYSTREAM_BYTES,
+        >(&ZERO_KEY, &ZERO_IETF_NONCE, None, None);
     }
 
     #[quickcheck]
@@ -599,12 +687,11 @@ mod public {
     fn prop_streamcipher_interface(input: Vec<u8>) -> bool {
         let sk = SecretKey::generate().unwrap();
         let n = Nonce::from(ZERO_IETF_NONCE);
-        StreamcipherTester::<ChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
-            sk.unprotected_as_ref(),
-            n.as_ref(),
-            Some(&input),
-            None,
-        );
+        StreamcipherTester::<ChaCha20>::run_tests::<
+            CHACHA_BLOCKSIZE,
+            { u32::MAX },
+            MAX_KEYSTREAM_BYTES,
+        >(sk.unprotected_as_ref(), n.as_ref(), Some(&input), None);
 
         true
     }
@@ -1079,6 +1166,7 @@ mod private {
                     U32x4(0, 0, 0, 0),
                 ],
                 keystreamblock: [0u8; CHACHA_BLOCKSIZE],
+                blockoffset: 0u8,
                 streampos: (u32::MAX - 128),
                 exhausted: false,
             };
@@ -1118,6 +1206,7 @@ mod private {
                     U32x4(0, 0, 0, 0),
                 ],
                 keystreamblock: [0u8; CHACHA_BLOCKSIZE],
+                blockoffset: 0u8,
                 streampos: (u32::MAX - 2),
                 exhausted: false,
             };

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -97,6 +97,7 @@ use crate::{
     generics::GeneratePublic,
     hazardous::stream::chacha20::{ChaCha20, HCHACHA_NONCESIZE},
 };
+#[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
 /// The nonce size for XChaCha20.

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -21,30 +21,19 @@
 // SOFTWARE.
 
 //! # Parameters:
-//! - `secret_key`: The secret key.
-//! - `nonce`: The nonce value.
-//! - `initial_counter`: The initial counter value. In most cases, this is `0`.
-//! - `ciphertext`: The encrypted data.
-//! - `plaintext`: The data to be encrypted.
-//! - `dst_out`: Destination array that will hold the ciphertext/plaintext after
-//!   encryption/decryption.
-//!
-//! `dst_out`: The output buffer may have a capacity greater than the input. If this is the case,
-//! only the first input length amount of bytes in `dst_out` are modified, while the rest remain untouched.
+//! - `sk`: The secret key.
+//! - `n`: The nonce value.
+//! - `blockctr`: The position within the keystream.
+//! - `bytes`: Bytes to apply the keystream to.
 //!
 //! # Errors:
 //! An error will be returned if:
-//! - The length of `dst_out` is less than `plaintext` or `ciphertext`.
-//! - `plaintext` or `ciphertext` is empty.
-//! - The `initial_counter` is high enough to cause a potential overflow.
-//!
-//! Even though `dst_out` is allowed to be of greater length than `plaintext`,
-//! the `ciphertext` produced by `chacha20`/`xchacha20` will always be of the
-//! same length as the `plaintext`.
-//!
-//! # Panics:
-//! A panic will occur if:
-//! - More than `2^32-1 * 64` bytes of data are processed.
+//! - The [`XChaCha20::next_producible()`] returns err.
+//! - If a keystream block (64 bytes) has been generated with [`XChaCha20::position()`] [`u32::MAX`],
+//!   and [`XChaCha20::xor_keystream_into()`] is called subsequently. Generating the last keystream block
+//!   moves [`XChaCha20`] into an exhausted state, which is non-resettable. In this case, the key/nonce pair
+//!   has generated all possible keystream bytes and is thus not safe to use further.
+//!   This can be checked with [`XChaCha20::is_exhausted()`].
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
@@ -63,37 +52,52 @@
 //! # Example:
 //! ```rust
 //! # #[cfg(feature = "safe_api")] {
-//! use orion::hazardous::stream::xchacha20;
+//! use orion::hazardous::stream::xchacha20::{SecretKey, Nonce, XChaCha20};
 //!
-//! let secret_key = xchacha20::SecretKey::generate()?;
-//! let nonce = xchacha20::Nonce::generate()?;
-//! let message = "Data to protect".as_bytes();
+//! let sk = SecretKey::generate()?;
+//! let n = Nonce::generate()?;
+//! let mut ctx = XChaCha20::new(&sk, &n);
 //!
-//! // Length of this message is 15
+//! // Encrypting a message:
+//! let mut message: [u8; 15] = *b"Data to protect";
+//! ctx.xor_keystream_into(&mut message)?;
+//! // Decrypt (re-apply keystream):
+//! ctx.set_position(0); // reset to beginning
+//! ctx.xor_keystream_into(&mut message)?;
 //!
-//! let mut dst_out_pt = [0u8; 15];
-//! let mut dst_out_ct = [0u8; 15];
+//! assert_eq!("Data to protect".as_bytes(), message);
 //!
-//! xchacha20::encrypt(&secret_key, &nonce, 0, message, &mut dst_out_ct)?;
+//! // Seeking ahead in keystream. This example generates the 256th keystream block (64 bytes):
+//! ctx.set_position(256);
+//! let mut keystream_block = [0u8; 64];
+//! ctx.xor_keystream_into(&mut keystream_block)?;
 //!
-//! xchacha20::decrypt(&secret_key, &nonce, 0, &dst_out_ct, &mut dst_out_pt)?;
-//!
-//! assert_eq!(dst_out_pt, message);
 //! # }
 //! # Ok::<(), orion::errors::UnknownCryptoError>(())
 //! ```
 //! [`SecretKey::generate()`]: xchacha20::SecretKey::generate()
 //! [`Nonce::generate()`]: xchacha20::Nonce::generate()
 //! [`XChaCha20Poly1305`]: super::aead::xchacha20poly1305
-use crate::generics::GeneratePublic;
+//! [`XChaCha20`]: xchacha20::XChaCha20
+//! [`XChaCha20::xor_keystream_into()`]: xchacha20::XChaCha20::xor_keystream_into()
+//! [`XChaCha20::position()`]: xchacha20::XChaCha20::position()
+//! [`XChaCha20::is_exhausted()`]: xchacha20::XChaCha20::is_exhausted()
+//! [`XChaCha20::next_producible()`]: xchacha20::XChaCha20::next_producible()
+
 #[cfg(feature = "safe_api")]
 use crate::generics::sealed::Data;
+pub use crate::hazardous::stream::chacha20::CHACHA_BLOCKSIZE;
 pub use crate::hazardous::stream::chacha20::SecretKey;
 use crate::{
     errors::UnknownCryptoError,
     generics::{ByteArrayData, Public, TypeSpec, sealed::Sealed},
-    hazardous::stream::chacha20::{self, IETF_CHACHA_NONCESIZE, Nonce as IETFNonce},
+    hazardous::stream::chacha20::{IETF_CHACHA_NONCESIZE, Nonce as IETFNonce},
 };
+use crate::{
+    generics::GeneratePublic,
+    hazardous::stream::chacha20::{ChaCha20, HCHACHA_NONCESIZE},
+};
+use zeroize::Zeroize;
 
 /// The nonce size for XChaCha20.
 pub const XCHACHA_NONCESIZE: usize = 24;
@@ -127,48 +131,128 @@ impl GeneratePublic for XChaCha20Nonce {
 /// A type that represents a [`Nonce`] that XChaCha20 and XChaCha20-Poly1305 use.
 pub type Nonce = Public<XChaCha20Nonce>;
 
-/// Generate a subkey using HChaCha20 for XChaCha20 and corresponding nonce.
-pub(crate) fn subkey_and_nonce(secret_key: &SecretKey, nonce: &Nonce) -> (SecretKey, IETFNonce) {
-    // .unwrap() should not be able to panic because we pass a 16-byte nonce.
-    let subkey: SecretKey =
-        SecretKey::from(chacha20::hchacha20(secret_key, &nonce.as_ref()[0..16]).unwrap());
-    let mut prefixed_nonce = [0u8; IETF_CHACHA_NONCESIZE];
-    prefixed_nonce[4..IETF_CHACHA_NONCESIZE].copy_from_slice(&nonce.as_ref()[16..24]);
-
-    (subkey, IETFNonce::from(prefixed_nonce))
+#[derive(Clone, Debug)]
+/// XChaCha20 as specified in the [draft RFC](https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03).
+pub struct XChaCha20 {
+    chacha20: ChaCha20,
 }
 
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// XChaCha20 encryption as specified in the [draft RFC](https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03).
-pub fn encrypt(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    initial_counter: u32,
-    plaintext: &[u8],
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    let (subkey, ietf_nonce) = subkey_and_nonce(secret_key, nonce);
-
-    chacha20::encrypt(&subkey, &ietf_nonce, initial_counter, plaintext, dst_out)
+impl Drop for XChaCha20 {
+    fn drop(&mut self) {
+        #[cfg(feature = "zeroize")]
+        self.chacha20.zeroize();
+    }
 }
 
-#[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-/// XChaCha20 decryption as specified in the [draft RFC](https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03).
-pub fn decrypt(
-    secret_key: &SecretKey,
-    nonce: &Nonce,
-    initial_counter: u32,
-    ciphertext: &[u8],
-    dst_out: &mut [u8],
-) -> Result<(), UnknownCryptoError> {
-    encrypt(secret_key, nonce, initial_counter, ciphertext, dst_out)
+impl XChaCha20 {
+    /// Generate a subkey using HChaCha20 for XChaCha20 and corresponding nonce.
+    pub(crate) fn subkey_and_ietf_nonce(sk: &SecretKey, n: &Nonce) -> (SecretKey, IETFNonce) {
+        let mut hchacha_nonce = [0u8; HCHACHA_NONCESIZE];
+        hchacha_nonce.copy_from_slice(&n.data.bytes[..16]);
+
+        let subkey = SecretKey::from(ChaCha20::hchacha(sk, &hchacha_nonce));
+        let mut prefixed_nonce = [0u8; IETF_CHACHA_NONCESIZE];
+        prefixed_nonce[4..IETF_CHACHA_NONCESIZE].copy_from_slice(&n.data.bytes[16..24]);
+
+        (subkey, IETFNonce::from(prefixed_nonce))
+    }
+
+    /// Create a new [`XChaCha20`] instance.
+    pub fn new(sk: &SecretKey, n: &Nonce) -> Self {
+        let (subkey, ietf_nonce) = Self::subkey_and_ietf_nonce(sk, n);
+
+        Self {
+            chacha20: ChaCha20::new(&subkey, &ietf_nonce),
+        }
+    }
+
+    /// Return `true` if the last keystream block has been generated.
+    pub fn is_exhausted(&self) -> bool {
+        self.chacha20.is_exhausted()
+    }
+
+    /// Check that we can produce one more keystream block, given the current state.
+    ///
+    /// Return error if advancing the internal state position by one would overflow [`u32::MAX`],
+    /// or the keystream has been exhausted (see [`Self::is_exhausted`]).
+    pub fn next_producible(&self) -> Result<(), UnknownCryptoError> {
+        self.chacha20.next_producible()
+    }
+
+    /// Given the current [`Self::position`], determine how many keystream
+    /// bytes can be generated from here on out.
+    pub fn keystream_remaining(&self) -> u64 {
+        self.chacha20.keystream_remaining()
+    }
+
+    /// Set the position/counter of the [`XChaCha20`] state.
+    /// This is equivalent to seeking ahead in the keystream output generated,
+    /// for a given pair of [`SecretKey`] and [`Nonce`].
+    pub fn set_position(&mut self, blockctr: u32) {
+        self.chacha20.set_position(blockctr);
+    }
+
+    /// Return the current position within the keystream.
+    pub fn position(&self) -> u32 {
+        self.chacha20.position()
+    }
+
+    #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
+    /// Produce keystream blocks, based on the [`XChaCha20::position()`], and XOR into `bytes`.
+    ///
+    /// # NOTE:
+    /// When explicitly generating keystream blocks, e.g. with a combination of [`XChaCha20::set_position()`],
+    /// and this one, no leftover handling is performed. If `bytes` is less than [`CHACHA_BLOCKSIZE`] or not
+    /// a multiple thereof, the leftover bytes are not saved. This function will always generate a keystream block
+    /// based on the current position and if `bytes` cannot hold all [`CHACHA_BLOCKSIZE`] bytes, then they are "forgotten".
+    ///
+    ///
+    /// # SECURITY:
+    /// If this returns [`UnknownCryptoError`], then not all `bytes` have been processed.
+    /// Take care to zero out the bytes if this contains sensitive information.
+    pub fn xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError> {
+        self.chacha20.xor_keystream_into(bytes)
+    }
 }
 
 // Testing public functions in the module.
 #[cfg(test)]
 #[cfg(feature = "safe_api")]
 mod public {
+    use crate::{
+        hazardous::stream::chacha20::{CHACHA_BLOCKSIZE, CHACHA_KEYSIZE},
+        test_framework::streamcipher_interface::{StreamcipherTester, TestableStreamCipher},
+    };
+
     use super::*;
+
+    const ZERO_KEY: [u8; CHACHA_KEYSIZE] = [0u8; CHACHA_KEYSIZE];
+    const ZERO_XNONCE: [u8; XCHACHA_NONCESIZE] = [0u8; XCHACHA_NONCESIZE];
+
+    #[test]
+    fn test_keystream_remaining() {
+        let sk = SecretKey::from(ZERO_KEY);
+        let nonce = Nonce::from(ZERO_XNONCE);
+        let mut ctx = XChaCha20::new(&sk, &nonce);
+
+        ctx.set_position(0);
+        assert_eq!(ctx.position(), 0);
+        assert_eq!(
+            ctx.keystream_remaining(),
+            (CHACHA_BLOCKSIZE as u64) * 2u64.pow(32)
+        );
+
+        ctx.set_position(1);
+        assert_eq!(ctx.position(), 1);
+        assert_eq!(
+            ctx.keystream_remaining(),
+            crate::hazardous::aead::chacha20poly1305::P_MAX
+        );
+
+        ctx.set_position(u32::MAX);
+        assert_eq!(ctx.position(), u32::MAX);
+        assert_eq!(ctx.keystream_remaining(), 64);
+    }
 
     #[test]
     fn test_xchacha20_nonce() {
@@ -185,25 +269,77 @@ mod public {
         PublicNewtype::test_serialization::<XCHACHA_NONCESIZE, XChaCha20Nonce>();
     }
 
-    mod test_encrypt_decrypt {
-        use super::*;
-        use crate::test_framework::streamcipher_interface::*;
-
-        impl TestingRandom for Nonce {
-            fn gen_new() -> Self {
-                Self::generate().unwrap()
-            }
+    impl TestableStreamCipher for XChaCha20 {
+        fn _new(sk: &[u8], n: &[u8]) -> Self {
+            Self::new(
+                &SecretKey::try_from(sk).unwrap(),
+                &Nonce::try_from(n).unwrap(),
+            )
         }
 
-        #[quickcheck]
+        #[cfg(test)]
         #[cfg(feature = "safe_api")]
-        fn prop_streamcipher_interface(input: Vec<u8>, counter: u32) -> bool {
-            let secret_key = SecretKey::generate().unwrap();
-            let nonce = Nonce::generate().unwrap();
-            StreamCipherTestRunner(encrypt, decrypt, secret_key, nonce, counter, &input, None);
-            test_diff_params_diff_output(&encrypt, &decrypt);
+        fn _random() -> Self {
+            use rand::RngExt;
+            let mut rng = rand::rng();
+            let rand_sk: bool = rng.random();
 
-            true
+            let (sk, n) = if rand_sk {
+                (SecretKey::generate().unwrap(), Nonce::from(ZERO_XNONCE))
+            } else {
+                (SecretKey::from(ZERO_KEY), Nonce::generate().unwrap())
+            };
+
+            Self::_new(sk.unprotected_as_ref(), n.as_ref())
         }
+
+        fn _next_producible(&self) -> Result<(), UnknownCryptoError> {
+            self.next_producible()
+        }
+
+        fn _keystream_remaining(&self) -> u64 {
+            self.keystream_remaining()
+        }
+
+        fn _set_position(&mut self, blockctr: u32) {
+            self.set_position(blockctr);
+        }
+
+        fn _position(&self) -> u32 {
+            self.position()
+        }
+
+        fn _xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError> {
+            self.xor_keystream_into(bytes)
+        }
+
+        fn _is_exhausted(&self) -> bool {
+            self.is_exhausted()
+        }
+    }
+
+    #[test]
+    fn test_streamcipher() {
+        StreamcipherTester::<XChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
+            &ZERO_KEY,
+            &ZERO_XNONCE,
+            None,
+            None,
+        );
+    }
+
+    #[quickcheck]
+    #[cfg(feature = "safe_api")]
+    fn prop_streamcipher_interface(input: Vec<u8>) -> bool {
+        let sk = SecretKey::generate().unwrap();
+        let n = Nonce::from(ZERO_XNONCE);
+        StreamcipherTester::<XChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
+            sk.unprotected_as_ref(),
+            n.as_ref(),
+            Some(&input),
+            None,
+        );
+
+        true
     }
 }

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -193,9 +193,20 @@ impl XChaCha20 {
         self.chacha20.set_position(blockctr);
     }
 
-    /// Return the current position within the keystream.
+    /// Set the byte position within the [`XChaCha20`] state. This will set the correct
+    /// state block counter internally and any offset if needed.
+    pub fn set_byte_position(&mut self, pos: u64) -> Result<(), UnknownCryptoError> {
+        self.chacha20.set_byte_position(pos)
+    }
+
+    /// Get the current position/counter of the [`ChaCha20`] state, as a block.
     pub fn position(&self) -> u32 {
         self.chacha20.position()
+    }
+
+    /// Get the current position/counter of the [`ChaCha20`] state, as a byte-index.
+    pub fn byte_position(&mut self) -> u64 {
+        self.chacha20.byte_position()
     }
 
     #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
@@ -221,7 +232,7 @@ impl XChaCha20 {
 #[cfg(feature = "safe_api")]
 mod public {
     use crate::{
-        hazardous::stream::chacha20::{CHACHA_BLOCKSIZE, CHACHA_KEYSIZE},
+        hazardous::stream::chacha20::{CHACHA_BLOCKSIZE, CHACHA_KEYSIZE, MAX_KEYSTREAM_BYTES},
         test_framework::streamcipher_interface::{StreamcipherTester, TestableStreamCipher},
     };
 
@@ -317,16 +328,25 @@ mod public {
         fn _is_exhausted(&self) -> bool {
             self.is_exhausted()
         }
+
+        fn _set_byte_position(&mut self, pos: u64) -> Result<(), UnknownCryptoError> {
+            self.set_byte_position(pos)
+        }
+
+        fn _byte_position(&mut self) -> u64 {
+            self.byte_position()
+        }
+
+        const MAX_KEYSTREAM_BYTES: u64 = MAX_KEYSTREAM_BYTES;
     }
 
     #[test]
     fn test_streamcipher() {
-        StreamcipherTester::<XChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
-            &ZERO_KEY,
-            &ZERO_XNONCE,
-            None,
-            None,
-        );
+        StreamcipherTester::<XChaCha20>::run_tests::<
+            CHACHA_BLOCKSIZE,
+            { u32::MAX },
+            MAX_KEYSTREAM_BYTES,
+        >(&ZERO_KEY, &ZERO_XNONCE, None, None);
     }
 
     #[quickcheck]
@@ -334,12 +354,11 @@ mod public {
     fn prop_streamcipher_interface(input: Vec<u8>) -> bool {
         let sk = SecretKey::generate().unwrap();
         let n = Nonce::from(ZERO_XNONCE);
-        StreamcipherTester::<XChaCha20>::run_tests::<CHACHA_BLOCKSIZE, { u32::MAX }>(
-            sk.unprotected_as_ref(),
-            n.as_ref(),
-            Some(&input),
-            None,
-        );
+        StreamcipherTester::<XChaCha20>::run_tests::<
+            CHACHA_BLOCKSIZE,
+            { u32::MAX },
+            MAX_KEYSTREAM_BYTES,
+        >(sk.unprotected_as_ref(), n.as_ref(), Some(&input), None);
 
         true
     }

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -34,6 +34,7 @@
 //!   moves [`XChaCha20`] into an exhausted state, which is non-resettable. In this case, the key/nonce pair
 //!   has generated all possible keystream bytes and is thus not safe to use further.
 //!   This can be checked with [`XChaCha20::is_exhausted()`].
+//! - If [`XChaCha20::set_byte_position()`] is called with a `pos` that is equal to or greater than [`MAX_KEYSTREAM_BYTES`].
 //!
 //! # Security:
 //! - It is critical for security that a given nonce is not re-used with a given
@@ -83,10 +84,12 @@
 //! [`XChaCha20::position()`]: xchacha20::XChaCha20::position()
 //! [`XChaCha20::is_exhausted()`]: xchacha20::XChaCha20::is_exhausted()
 //! [`XChaCha20::next_producible()`]: xchacha20::XChaCha20::next_producible()
+//! [`XChaCha20::set_byte_position()`]: xchacha20::XChaCha20::set_byte_position()
 
 #[cfg(feature = "safe_api")]
 use crate::generics::sealed::Data;
 pub use crate::hazardous::stream::chacha20::CHACHA_BLOCKSIZE;
+pub use crate::hazardous::stream::chacha20::MAX_KEYSTREAM_BYTES;
 pub use crate::hazardous::stream::chacha20::SecretKey;
 use crate::{
     errors::UnknownCryptoError,
@@ -174,8 +177,7 @@ impl XChaCha20 {
 
     /// Check that we can produce one more keystream block, given the current state.
     ///
-    /// Return error if advancing the internal state position by one would overflow [`u32::MAX`],
-    /// or the keystream has been exhausted (see [`Self::is_exhausted`]).
+    /// Return error if [`Self::is_exhausted()`].
     pub fn next_producible(&self) -> Result<(), UnknownCryptoError> {
         self.chacha20.next_producible()
     }

--- a/src/hazardous/stream/xchacha20.rs
+++ b/src/hazardous/stream/xchacha20.rs
@@ -186,9 +186,16 @@ impl XChaCha20 {
         self.chacha20.keystream_remaining()
     }
 
-    /// Set the position/counter of the [`XChaCha20`] state.
+    /// Set the position/counter of the [`XChaCha20`] state, to a specific block.
+    ///
+    /// # NOTE:
+    /// This resets the internal offset tracker, which keeps track of unused
+    /// but already generated keystream bytes, for the [`Self::position()`]
+    /// prior to calling this function. To set position in terms of specific
+    /// bytes across the entire keystream, use
+    ///
     /// This is equivalent to seeking ahead in the keystream output generated,
-    /// for a given pair of [`SecretKey`] and [`Nonce`].
+    /// on a per-block ([`CHACHA_BLOCKSIZE`]) basis.
     pub fn set_position(&mut self, blockctr: u32) {
         self.chacha20.set_position(blockctr);
     }
@@ -199,25 +206,18 @@ impl XChaCha20 {
         self.chacha20.set_byte_position(pos)
     }
 
-    /// Get the current position/counter of the [`ChaCha20`] state, as a block.
+    /// Get the current position/counter of the [`XChaCha20`] state, as a block.
     pub fn position(&self) -> u32 {
         self.chacha20.position()
     }
 
-    /// Get the current position/counter of the [`ChaCha20`] state, as a byte-index.
+    /// Get the current position/counter of the [`XChaCha20`] state, as a byte-index.
     pub fn byte_position(&mut self) -> u64 {
         self.chacha20.byte_position()
     }
 
     #[must_use = "SECURITY WARNING: Ignoring a Result can have real security implications."]
-    /// Produce keystream blocks, based on the [`XChaCha20::position()`], and XOR into `bytes`.
-    ///
-    /// # NOTE:
-    /// When explicitly generating keystream blocks, e.g. with a combination of [`XChaCha20::set_position()`],
-    /// and this one, no leftover handling is performed. If `bytes` is less than [`CHACHA_BLOCKSIZE`] or not
-    /// a multiple thereof, the leftover bytes are not saved. This function will always generate a keystream block
-    /// based on the current position and if `bytes` cannot hold all [`CHACHA_BLOCKSIZE`] bytes, then they are "forgotten".
-    ///
+    /// Produce keystream blocks, based on the [`XChaCha20::byte_position()`], and XOR into `bytes`.
     ///
     /// # SECURITY:
     /// If this returns [`UnknownCryptoError`], then not all `bytes` have been processed.

--- a/src/high_level/aead.rs
+++ b/src/high_level/aead.rs
@@ -53,9 +53,6 @@
 //! - The received tag does not match the calculated tag when calling [`open`].
 //! - `plaintext.len()` + [`XCHACHA_NONCESIZE`] + [`POLY1305_OUTSIZE`] overflows when calling [`seal`].
 //! - Failure to generate random bytes securely.
-//!
-//! # Panics:
-//! A panic will occur if:
 //! - More than 2^32-1 * 64 bytes of data are processed.
 //!
 //! # Security:
@@ -108,7 +105,7 @@ pub fn seal(secret_key: &SecretKey, plaintext: &[u8]) -> Result<Vec<u8>, Unknown
     let nonce = Nonce::generate()?;
     dst_out[..XCHACHA_NONCESIZE].copy_from_slice(nonce.as_ref());
 
-    aead::xchacha20poly1305::seal(
+    aead::xchacha20poly1305::XChaCha20Poly1305::seal(
         &XChaCha20Key::try_from(secret_key.unprotected_as_ref())?,
         &nonce,
         plaintext,
@@ -133,7 +130,7 @@ pub fn open(
     let mut dst_out =
         vec![0u8; ciphertext_with_tag_and_nonce.len() - (XCHACHA_NONCESIZE + POLY1305_OUTSIZE)];
 
-    aead::xchacha20poly1305::open(
+    aead::xchacha20poly1305::XChaCha20Poly1305::open(
         &XChaCha20Key::try_from(secret_key.unprotected_as_ref())?,
         &Nonce::try_from(&ciphertext_with_tag_and_nonce[..XCHACHA_NONCESIZE])?,
         &ciphertext_with_tag_and_nonce[XCHACHA_NONCESIZE..],

--- a/src/test_framework/aead_interface.rs
+++ b/src/test_framework/aead_interface.rs
@@ -21,17 +21,588 @@
 // SOFTWARE.
 
 #![allow(non_snake_case)]
+
+use core::marker::PhantomData;
+
 #[cfg(feature = "safe_api")]
 use crate::errors::UnknownCryptoError;
+use crate::{Public, Secret, generics::TypeSpec, hazardous::stream::chacha20::CHACHA_BLOCKSIZE};
+use core::fmt::Debug;
 
-#[cfg(test)]
-#[cfg(feature = "safe_api")]
-use crate::test_framework::streamcipher_interface::TestingRandom;
+#[cfg(all(feature = "alloc", not(feature = "safe_api")))]
+use alloc::vec;
+
+pub trait TestableAead: Debug {
+    type Key: TypeSpec;
+    type Nonce: TypeSpec;
+    type Tag: TypeSpec + Clone;
+
+    fn _seal_inplace(
+        sk: &Secret<Self::Key>,
+        n: &Public<Self::Nonce>,
+        ad: Option<&[u8]>,
+        bytes: &mut [u8],
+    ) -> Result<Secret<Self::Tag>, UnknownCryptoError>;
+
+    fn _open_inplace(
+        sk: &Secret<Self::Key>,
+        n: &Public<Self::Nonce>,
+        tag: &Secret<Self::Tag>,
+        ad: Option<&[u8]>,
+        bytes: &mut [u8],
+    ) -> Result<(), UnknownCryptoError>;
+
+    fn _seal(
+        sk: &Secret<Self::Key>,
+        n: &Public<Self::Nonce>,
+        plaintext: &[u8],
+        ad: Option<&[u8]>,
+        dst_out: &mut [u8],
+    ) -> Result<(), UnknownCryptoError>;
+
+    fn _open(
+        sk: &Secret<Self::Key>,
+        n: &Public<Self::Nonce>,
+        ciphertext_with_tag: &[u8],
+        ad: Option<&[u8]>,
+        dst_out: &mut [u8],
+    ) -> Result<(), UnknownCryptoError>;
+}
+
+#[derive(Debug)]
+/// KS: Key-size
+/// NS: Nonce-size.
+/// TS: Tag-size.
+pub struct AeadTestRunner<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize> {
+    _aead: PhantomData<Aead>,
+}
+
+impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
+    AeadTestRunner<Aead, KS, NS, TS>
+{
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    pub fn run_with_testvector(
+        sk: &[u8],
+        n: &[u8],
+        aad: &[u8],
+        plaintext: &[u8],
+        expected_ct: &[u8],
+        expected_tag: &[u8],
+    ) -> Result<(), UnknownCryptoError> {
+        let default_aad = if aad.is_empty() { None } else { Some(aad) };
+
+        let sk = Secret::<Aead::Key>::try_from(sk)?;
+        let n = Public::<Aead::Nonce>::try_from(n)?;
+        let tag = Secret::<Aead::Tag>::try_from(expected_tag)?;
+
+        let mut dst_out_ct = vec![0u8; plaintext.len() + TS];
+        Aead::_seal(&sk, &n, plaintext, default_aad, &mut dst_out_ct)?;
+        assert_eq!(&dst_out_ct[..plaintext.len()], expected_ct);
+        assert_eq!(
+            &dst_out_ct[plaintext.len()..plaintext.len() + TS],
+            expected_tag
+        );
+
+        let mut dst_out_ct_inplace = plaintext.to_vec();
+        let actual_tag = Aead::_seal_inplace(&sk, &n, default_aad, &mut dst_out_ct_inplace)?;
+        assert_eq!(&dst_out_ct_inplace, expected_ct);
+        assert_eq!(actual_tag, expected_tag);
+
+        let mut dst_out_pt = vec![0u8; plaintext.len()];
+        Aead::_open(&sk, &n, &dst_out_ct, default_aad, &mut dst_out_pt)?;
+        assert_eq!(&dst_out_pt, plaintext);
+
+        Aead::_open_inplace(&sk, &n, &tag, default_aad, &mut dst_out_ct_inplace)?;
+        assert_eq!(&dst_out_ct_inplace, plaintext);
+
+        Ok(())
+    }
+
+    pub fn run_all_tests(input: &[u8]) {
+        Self::test_seal_zero_length_input_is_ok();
+
+        #[cfg(any(feature = "safe_api", feature = "alloc"))]
+        {
+            Self::test_seal_open_not_using_out_bytes();
+            Self::test_wrong_aad_fails();
+            Self::test_wrong_nonce_fails();
+            Self::test_wrong_key_fails();
+            Self::test_wrong_tag_fails();
+            Self::test_none_or_empty_some_aad_same_result();
+            Self::test_lengths_ad();
+            Self::test_lengths_pt_ct();
+            Self::test_inplace_buffered_interop(input);
+            Self::test_wrong_ciphertext_fails();
+        }
+
+        #[cfg(all(feature = "safe_api", test))]
+        {
+            Self::test_rng_nonce_or_key_different_ciphertext();
+        }
+    }
+
+    fn secret_key_nonce() -> (Secret<Aead::Key>, Public<Aead::Nonce>) {
+        #[cfg(all(feature = "safe_api", test))]
+        {
+            // safe_api + test gives us dev-dep rand
+            use rand::Rng;
+            let mut rng = rand::rng();
+
+            let mut skbytes = [0u8; KS];
+            let mut nbytes = [0u8; NS];
+            rng.fill_bytes(&mut skbytes);
+            rng.fill_bytes(&mut nbytes);
+
+            let sk = Secret::<Aead::Key>::try_from(&skbytes).unwrap();
+            let n = Public::<Aead::Nonce>::try_from(&nbytes).unwrap();
+
+            (sk, n)
+        }
+
+        #[cfg(not(all(feature = "safe_api", test)))]
+        {
+            let sk = Secret::<Aead::Key>::try_from(&[0u8; KS]).unwrap();
+            let n = Public::<Aead::Nonce>::try_from(&[0u8; NS]).unwrap();
+
+            (sk, n)
+        }
+    }
+
+    // seal()/seal_inplace() should accept zero-length input and produce a authentication tag over this.
+    fn test_seal_zero_length_input_is_ok() {
+        let (sk, n) = Self::secret_key_nonce();
+
+        let mut dst_out = [0u8; TS];
+        let mut bytes = [0u8; 0];
+
+        // seal requires space for Tag
+        assert!(Aead::_seal(&sk, &n, b"", None, &mut bytes).is_err());
+        assert!(Aead::_seal(&sk, &n, b"", None, &mut dst_out).is_ok());
+        let tag = Aead::_seal_inplace(&sk, &n, None, &mut bytes)
+            .expect("failed to accept zero-len input seal_inplace()");
+        assert_eq!(tag, &dst_out);
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_lengths_ad() {
+        // Tests different lengths in relation to the padding to Poly1305 blocksize that happens
+        const LENGHTS: [usize; 5] = [0, 1, 15, 16, 17];
+        let (sk, n) = Self::secret_key_nonce();
+
+        let mut dst_out = vec![0u8; 32 + TS];
+        let mut dst_out_pt = [0u8; 32];
+        let mut bytes = [123u8; 32];
+        for len in LENGHTS {
+            let ad = vec![1u8; len];
+            Aead::_seal(&sk, &n, &[123u8; 32], Some(&ad), &mut dst_out).unwrap();
+            Aead::_open(&sk, &n, &dst_out, Some(&ad), &mut dst_out_pt).unwrap();
+            assert_eq!(&dst_out_pt, &[123u8; 32]);
+
+            let t = Aead::_seal_inplace(&sk, &n, Some(&ad), &mut bytes).unwrap();
+            assert_eq!(&dst_out[..32], &bytes);
+            assert_eq!(t, &dst_out[32..]);
+            Aead::_open_inplace(&sk, &n, &t, Some(&ad), &mut bytes).unwrap();
+            assert_eq!(&bytes, &[123u8; 32]);
+        }
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    /// Related bug: <https://github.com/orion-rs/orion/issues/52>
+    /// Test input sizes when using seal()/open().
+    fn test_lengths_pt_ct() {
+        // Tests different lengths in relation to the padding to Poly1305 blocksize that happens
+        // and ChaCha blocksize.
+        const LENGHTS: [usize; 10] = [0, 1, 15, 16, 17, 32, 63, 64, 65, 128];
+        let (sk, n) = Self::secret_key_nonce();
+
+        for len in LENGHTS {
+            let plaintext = vec![121u8; len];
+            let mut dst_out = vec![0u8; len + TS];
+            let mut dst_out_pt = vec![0u8; len];
+            let mut bytes = plaintext.to_vec();
+
+            Aead::_seal(&sk, &n, &plaintext, None, &mut dst_out).unwrap();
+            Aead::_open(&sk, &n, &dst_out, None, &mut dst_out_pt).unwrap();
+            assert_eq!(&dst_out_pt, &plaintext);
+
+            // Test bytes provided too little, too much.
+            let mut dst_out_pt_save = vec![0u8; len];
+            if len != 0 {
+                assert!(
+                    Aead::_open(
+                        &sk,
+                        &n,
+                        &dst_out[..len + TS - 1],
+                        None,
+                        &mut dst_out_pt_save
+                    )
+                    .is_err()
+                );
+                let mut dst_out_dropped_ct = dst_out.clone();
+                dst_out_dropped_ct.remove(0);
+                assert!(
+                    Aead::_open(&sk, &n, &dst_out_dropped_ct, None, &mut dst_out_pt_save).is_err()
+                );
+                assert!(
+                    Aead::_open(&sk, &n, &dst_out, None, &mut dst_out_pt_save[..len - 1]).is_err()
+                );
+            }
+            let mut dst_out_more = dst_out.clone();
+            dst_out_more.push(1u8);
+            assert!(Aead::_open(&sk, &n, &dst_out_more, None, &mut dst_out_pt_save).is_err());
+            dst_out_pt_save.push(1u8);
+            assert!(Aead::_open(&sk, &n, &dst_out, None, &mut dst_out_pt_save).is_ok());
+
+            // NOTE: This one is only applicable for seal() as inplace() doesn't take btho in/out parameters.
+            // Test too small, perfect and larger for outsize (https://github.com/orion-rs/orion/issues/52)
+            let mut dst_out_ct_more = vec![0u8; plaintext.len() + (TS + 1)];
+            assert!(Aead::_seal(&sk, &n, &plaintext, None, &mut dst_out_ct_more).is_ok());
+            let mut dst_out_ct_more_double = vec![0u8; plaintext.len() + (TS * 2)];
+            assert!(Aead::_seal(&sk, &n, &plaintext, None, &mut dst_out_ct_more_double).is_ok());
+            let mut dst_out_ct_less = vec![0u8; plaintext.len() + (TS - 1)];
+            assert!(Aead::_seal(&sk, &n, &plaintext, None, &mut dst_out_ct_less).is_err());
+
+            let t = Aead::_seal_inplace(&sk, &n, None, &mut bytes).unwrap();
+            let mut bytes_ct_save = bytes.clone();
+            assert_eq!(&dst_out[..len], &bytes);
+            assert_eq!(t, &dst_out[len..len + TS]);
+            Aead::_open_inplace(&sk, &n, &t, None, &mut bytes).unwrap();
+            assert_eq!(&bytes, &plaintext);
+
+            // Test bytes provided too little, too much.
+            if len != 0 {
+                assert!(
+                    Aead::_open_inplace(&sk, &n, &t, None, &mut bytes_ct_save[..len - 1]).is_err()
+                );
+            }
+            bytes_ct_save.push(1u8);
+            // This cannot, comapred to open() be too large! This is because it needs to contain the entire
+            // ciphertext and only that, in order to authenticate it fully.
+            assert!(Aead::_open_inplace(&sk, &n, &t, None, &mut bytes_ct_save).is_err());
+        }
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_wrong_aad_fails() {
+        let (sk, n) = Self::secret_key_nonce();
+        let ad = Some("Additional context".as_bytes());
+
+        let mut dst_out_ct = vec![0u8; (CHACHA_BLOCKSIZE * 3) + TS];
+        let mut dst_out_pt = [0u8; CHACHA_BLOCKSIZE * 3];
+        let mut bytes = [123u8; CHACHA_BLOCKSIZE * 3];
+
+        Aead::_seal(&sk, &n, &[123u8; CHACHA_BLOCKSIZE * 3], ad, &mut dst_out_ct).unwrap();
+        let t = Aead::_seal_inplace(&sk, &n, ad, &mut bytes).unwrap();
+        // Capital starting letter differs in AD:
+        assert!(
+            Aead::_open(
+                &sk,
+                &n,
+                &dst_out_ct,
+                Some("additional context".as_bytes()),
+                &mut dst_out_pt
+            )
+            .is_err()
+        );
+        assert!(
+            Aead::_open_inplace(
+                &sk,
+                &n,
+                &t,
+                Some("additional context".as_bytes()),
+                &mut bytes
+            )
+            .is_err()
+        );
+        // SECURITY: Check that nothing was altered on failing verification,
+        // in terms of output (partial plaintext release).
+        assert_eq!(&dst_out_pt, &[0u8; CHACHA_BLOCKSIZE * 3]);
+        assert_eq!(bytes.as_slice(), &dst_out_ct[..dst_out_ct.len() - TS]);
+
+        assert!(Aead::_open(&sk, &n, &dst_out_ct, ad, &mut dst_out_pt).is_ok());
+        assert!(Aead::_open_inplace(&sk, &n, &t, ad, &mut bytes).is_ok());
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_wrong_nonce_fails() {
+        let (sk, n) = Self::secret_key_nonce();
+
+        let mut dst_out_ct = vec![0u8; (CHACHA_BLOCKSIZE * 3) + TS];
+        let mut dst_out_pt = [0u8; CHACHA_BLOCKSIZE * 3];
+        let mut bytes = [123u8; CHACHA_BLOCKSIZE * 3];
+
+        Aead::_seal(
+            &sk,
+            &n,
+            &[123u8; CHACHA_BLOCKSIZE * 3],
+            None,
+            &mut dst_out_ct,
+        )
+        .unwrap();
+        let t = Aead::_seal_inplace(&sk, &n, None, &mut bytes).unwrap();
+        let n_prime = Public::<Aead::Nonce>::try_from(&[1u8; NS]).unwrap();
+        assert!(Aead::_open(&sk, &n_prime, &dst_out_ct, None, &mut dst_out_pt).is_err());
+        assert!(Aead::_open_inplace(&sk, &n_prime, &t, None, &mut bytes).is_err());
+        // SECURITY: Check that nothing was altered on failing verification,
+        // in terms of output (partial plaintext release).
+        assert_eq!(&dst_out_pt, &[0u8; CHACHA_BLOCKSIZE * 3]);
+        assert_eq!(bytes.as_slice(), &dst_out_ct[..dst_out_ct.len() - TS]);
+
+        assert!(Aead::_open(&sk, &n, &dst_out_ct, None, &mut dst_out_pt).is_ok());
+        assert!(Aead::_open_inplace(&sk, &n, &t, None, &mut bytes).is_ok());
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_wrong_key_fails() {
+        let (sk, n) = Self::secret_key_nonce();
+
+        let mut dst_out_ct = vec![0u8; (CHACHA_BLOCKSIZE * 3) + TS];
+        let mut dst_out_pt = [0u8; CHACHA_BLOCKSIZE * 3];
+        let mut bytes = [123u8; CHACHA_BLOCKSIZE * 3];
+
+        Aead::_seal(
+            &sk,
+            &n,
+            &[123u8; CHACHA_BLOCKSIZE * 3],
+            None,
+            &mut dst_out_ct,
+        )
+        .unwrap();
+        let t = Aead::_seal_inplace(&sk, &n, None, &mut bytes).unwrap();
+        let sk_prime = Secret::<Aead::Key>::try_from(&[1u8; KS]).unwrap();
+        assert!(Aead::_open(&sk_prime, &n, &dst_out_ct, None, &mut dst_out_pt).is_err());
+        assert!(Aead::_open_inplace(&sk_prime, &n, &t, None, &mut bytes).is_err());
+        // SECURITY: Check that nothing was altered on failing verification,
+        // in terms of output (partial plaintext release).
+        assert_eq!(&dst_out_pt, &[0u8; CHACHA_BLOCKSIZE * 3]);
+        assert_eq!(bytes.as_slice(), &dst_out_ct[..dst_out_ct.len() - TS]);
+
+        assert!(Aead::_open(&sk, &n, &dst_out_ct, None, &mut dst_out_pt).is_ok());
+        assert!(Aead::_open_inplace(&sk, &n, &t, None, &mut bytes).is_ok());
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_wrong_ciphertext_fails() {
+        let (sk, n) = Self::secret_key_nonce();
+
+        let mut dst_out_ct = vec![0u8; (CHACHA_BLOCKSIZE * 3) + TS];
+        let mut dst_out_pt = [0u8; CHACHA_BLOCKSIZE * 3];
+        let mut bytes = [123u8; CHACHA_BLOCKSIZE * 3];
+
+        Aead::_seal(
+            &sk,
+            &n,
+            &[123u8; CHACHA_BLOCKSIZE * 3],
+            None,
+            &mut dst_out_ct,
+        )
+        .unwrap();
+        let t = Aead::_seal_inplace(&sk, &n, None, &mut bytes).unwrap();
+        let mut dst_out_ct_mod = dst_out_ct.clone();
+        let mut bytes_ct_mod = bytes;
+        dst_out_ct_mod[0] ^= 1;
+        bytes_ct_mod[0] ^= 1;
+
+        assert!(Aead::_open(&sk, &n, &dst_out_ct_mod, None, &mut dst_out_pt).is_err());
+        assert!(Aead::_open_inplace(&sk, &n, &t, None, &mut bytes_ct_mod).is_err());
+        // SECURITY: Check that nothing was altered on failing verification,
+        // in terms of output (partial plaintext release).
+        assert_eq!(&dst_out_pt, &[0u8; CHACHA_BLOCKSIZE * 3]);
+        assert_eq!(
+            bytes_ct_mod.as_slice(),
+            &dst_out_ct_mod[..dst_out_ct_mod.len() - TS]
+        );
+
+        assert!(Aead::_open(&sk, &n, &dst_out_ct, None, &mut dst_out_pt).is_ok());
+        assert!(Aead::_open_inplace(&sk, &n, &t, None, &mut bytes).is_ok());
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_wrong_tag_fails() {
+        let (sk, n) = Self::secret_key_nonce();
+
+        let mut dst_out_ct = vec![0u8; (CHACHA_BLOCKSIZE * 3) + TS];
+        let mut dst_out_pt = [0u8; CHACHA_BLOCKSIZE * 3];
+        let mut bytes = [123u8; CHACHA_BLOCKSIZE * 3];
+
+        Aead::_seal(
+            &sk,
+            &n,
+            &[123u8; CHACHA_BLOCKSIZE * 3],
+            None,
+            &mut dst_out_ct,
+        )
+        .unwrap();
+        let dst_out_ct_original = dst_out_ct.clone();
+
+        let t = Aead::_seal_inplace(&sk, &n, None, &mut bytes).unwrap();
+        dst_out_ct[CHACHA_BLOCKSIZE * 3] ^= 1;
+        let mut t_prime = t.unprotected_as_ref().to_vec();
+        t_prime[0] ^= 1;
+        let t_prime = Secret::<Aead::Tag>::try_from(&t_prime).unwrap();
+        assert!(Aead::_open(&sk, &n, &dst_out_ct, None, &mut dst_out_pt).is_err());
+        assert!(Aead::_open_inplace(&sk, &n, &t_prime, None, &mut bytes).is_err());
+        // SECURITY: Check that nothing was altered on failing verification,
+        // in terms of output (partial plaintext release).
+        assert_eq!(&dst_out_pt, &[0u8; CHACHA_BLOCKSIZE * 3]);
+        assert_eq!(
+            bytes.as_slice(),
+            &dst_out_ct_original[..dst_out_ct_original.len() - TS]
+        );
+
+        assert!(Aead::_open(&sk, &n, &dst_out_ct_original, None, &mut dst_out_pt).is_ok());
+        assert!(Aead::_open_inplace(&sk, &n, &t, None, &mut bytes).is_ok());
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_inplace_buffered_interop(input: &[u8]) {
+        let (sk, n) = Self::secret_key_nonce();
+        let ad = b"Additional context";
+
+        let mut dst_out_ct = vec![0u8; input.len() + TS];
+        let mut dst_out_pt = vec![0u8; input.len()];
+        let mut inplace_buffer = input.to_vec();
+
+        Aead::_seal(&sk, &n, input, Some(ad), &mut dst_out_ct).unwrap();
+        let tag = Aead::_seal_inplace(&sk, &n, Some(ad), &mut inplace_buffer).unwrap();
+
+        // Use inplace and separate tag for non-inplace and vice versa
+        inplace_buffer.extend_from_slice(tag.unprotected_as_ref());
+        assert!(Aead::_open(&sk, &n, &inplace_buffer, Some(ad), &mut dst_out_pt).is_ok());
+        assert_eq!(&dst_out_pt, input);
+
+        let tag =
+            Secret::<Aead::Tag>::try_from(&dst_out_ct[input.len()..input.len() + TS]).unwrap();
+        dst_out_ct.truncate(input.len());
+        assert!(Aead::_open_inplace(&sk, &n, &tag, Some(ad), &mut dst_out_ct).is_ok());
+        assert_eq!(&dst_out_ct, input);
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    /// Ensure that seal()/open() are not expecting `dst_out` bytes to be 0.
+    /// Not applicable to *_inplace() because they XOR the bytes directly, so the mutable
+    /// destination is the input.
+    fn test_seal_open_not_using_out_bytes() {
+        let sk = Secret::<Aead::Key>::try_from(&[0u8; KS]).unwrap();
+        let n = Public::<Aead::Nonce>::try_from(&[0u8; NS]).unwrap();
+
+        // seal()/open()
+        let mut dst_out_0 = vec![0u8; CHACHA_BLOCKSIZE + TS];
+        let mut dst_out_255 = vec![255u8; CHACHA_BLOCKSIZE + TS];
+        Aead::_seal(&sk, &n, &[123u8; CHACHA_BLOCKSIZE], None, &mut dst_out_0).unwrap();
+        Aead::_seal(&sk, &n, &[123u8; CHACHA_BLOCKSIZE], None, &mut dst_out_255).unwrap();
+        assert_eq!(dst_out_0, dst_out_255);
+
+        let mut rt_dst_out_0 = [0u8; CHACHA_BLOCKSIZE];
+        let mut rt_dst_out_255 = [255u8; CHACHA_BLOCKSIZE];
+        Aead::_open(&sk, &n, &dst_out_0, None, &mut rt_dst_out_0).unwrap();
+        Aead::_open(&sk, &n, &dst_out_255, None, &mut rt_dst_out_255).unwrap();
+        assert_eq!(&rt_dst_out_0, &[123u8; CHACHA_BLOCKSIZE]);
+        assert_eq!(&rt_dst_out_255, &[123u8; CHACHA_BLOCKSIZE]);
+    }
+
+    #[cfg(any(feature = "safe_api", feature = "alloc"))]
+    fn test_none_or_empty_some_aad_same_result() {
+        let sk = Secret::<Aead::Key>::try_from(&[0u8; KS]).unwrap();
+        let n = Public::<Aead::Nonce>::try_from(&[0u8; NS]).unwrap();
+
+        let mut dst_out_none = vec![0u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2) + TS];
+        let mut dst_out_some = vec![0u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2) + TS];
+        Aead::_seal(
+            &sk,
+            &n,
+            &[123u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)],
+            None,
+            &mut dst_out_none,
+        )
+        .unwrap();
+        Aead::_seal(
+            &sk,
+            &n,
+            &[123u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)],
+            Some(&[]),
+            &mut dst_out_some,
+        )
+        .unwrap();
+        assert_eq!(dst_out_none, dst_out_some);
+
+        let mut bytes_none = vec![123u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)];
+        let mut bytes_some = vec![123u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)];
+        let t_none = Aead::_seal_inplace(&sk, &n, None, &mut bytes_none).unwrap();
+        let t_some = Aead::_seal_inplace(&sk, &n, Some(&[]), &mut bytes_some).unwrap();
+        assert_eq!(bytes_none, bytes_some);
+
+        let mut dst_out_none_pt = vec![0u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)];
+        let mut dst_out_some_pt = vec![0u8; CHACHA_BLOCKSIZE + (CHACHA_BLOCKSIZE / 2)];
+        Aead::_open(&sk, &n, &dst_out_none, None, &mut dst_out_none_pt).unwrap();
+        Aead::_open(&sk, &n, &dst_out_some, Some(&[]), &mut dst_out_some_pt).unwrap();
+        assert_eq!(dst_out_none_pt, dst_out_some_pt);
+
+        Aead::_open_inplace(&sk, &n, &t_none, None, &mut bytes_none).unwrap();
+        Aead::_open_inplace(&sk, &n, &t_some, None, &mut bytes_some).unwrap();
+        assert_eq!(bytes_none, bytes_some);
+    }
+
+    #[cfg(all(feature = "safe_api", test))]
+    fn test_rng_nonce_or_key_different_ciphertext() {
+        // safe_api + test gives us dev-dep rand
+        use rand::{Rng, RngExt};
+        let mut rng = rand::rng();
+
+        let inlen: usize = rng.random_range(0..1024);
+        let adlen: usize = rng.random_range(0..512);
+        let mut input = vec![0u8; inlen];
+        let mut ad = vec![0u8; adlen];
+        let mut skbytes = [0u8; KS];
+        let mut nbytes = [0u8; NS];
+        rng.fill_bytes(&mut skbytes);
+        rng.fill_bytes(&mut nbytes);
+        rng.fill_bytes(&mut input);
+        rng.fill_bytes(&mut ad);
+
+        let sk = Secret::<Aead::Key>::try_from(&skbytes).unwrap();
+        let n = Public::<Aead::Nonce>::try_from(&nbytes).unwrap();
+
+        let ref_input = input.clone();
+        let ref_tag = Aead::_seal_inplace(&sk, &n, Some(&ad), &mut input).unwrap();
+        let ref_ct = input.clone();
+
+        input = ref_input.clone();
+        rng.fill_bytes(&mut skbytes);
+        let diff_sk = Secret::<Aead::Key>::try_from(&skbytes).unwrap();
+        let diff_tag = Aead::_seal_inplace(&diff_sk, &n, Some(&ad), &mut input).unwrap();
+        assert_ne!(diff_tag, ref_tag);
+        if !input.is_empty() {
+            assert_ne!(input, ref_ct);
+        }
+
+        input = ref_input.clone();
+        rng.fill_bytes(&mut nbytes);
+        let diff_n = Public::<Aead::Nonce>::try_from(&nbytes).unwrap();
+        let diff_tag = Aead::_seal_inplace(&sk, &diff_n, Some(&ad), &mut input).unwrap();
+        assert_ne!(diff_tag, ref_tag);
+        if !input.is_empty() {
+            assert_ne!(input, ref_ct);
+        }
+
+        if !ad.is_empty() {
+            input = ref_input.clone();
+            rng.fill_bytes(&mut ad);
+            let diff_tag = Aead::_seal_inplace(&sk, &n, Some(&ad), &mut input).unwrap();
+            assert_ne!(diff_tag, ref_tag);
+            // AD-difference only changes the Tag, not the ciphertext. If empty, always Eq.
+            assert_eq!(input, ref_ct);
+        }
+    }
+}
+
+// The following is from before seal_inplace()/open_inplace()
+// was supported. These tests are for buffered-only interfaces.
 
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "safe_api")]
 /// Test runner for AEADs.
-pub fn AeadTestRunner<Sealer, Opener, Key, Nonce>(
+pub fn BufferedOnlyAeadTestRunner<Sealer, Opener, Key, Nonce>(
     sealer: Sealer,
     opener: Opener,
     key: Key,
@@ -346,38 +917,4 @@ fn none_or_empty_some_aad_same_result<Sealer, Opener, Key, Nonce>(
         .is_ok()
     );
     assert!(opener(key, nonce, &dst_out_ct_some_empty, None, &mut dst_out_pt).is_ok());
-}
-
-#[cfg(test)]
-#[cfg(feature = "safe_api")]
-/// Test that sealing and opening with different secret-key/nonce yields an error.
-pub fn test_diff_params_err<Sealer, Opener, Key, Nonce>(
-    sealer: &Sealer,
-    opener: &Opener,
-    input: &[u8],
-    tag_size: usize,
-) where
-    Key: TestingRandom + PartialEq<Key>,
-    Nonce: TestingRandom + PartialEq<Nonce>,
-    Sealer: Fn(&Key, &Nonce, &[u8], Option<&[u8]>, &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Opener: Fn(&Key, &Nonce, &[u8], Option<&[u8]>, &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    let sk1 = Key::gen_new();
-    let sk2 = Key::gen_new();
-    assert!(sk1 != sk2);
-
-    let n1 = Nonce::gen_new();
-    let n2 = Nonce::gen_new();
-    assert!(n1 != n2);
-
-    let mut dst_out_ct = vec![0u8; input.len() + tag_size];
-    let mut dst_out_pt = vec![0u8; input.len()];
-
-    // Different secret key
-    sealer(&sk1, &n1, input, None, &mut dst_out_ct).unwrap();
-    assert!(opener(&sk2, &n1, &dst_out_ct, None, &mut dst_out_pt).is_err());
-
-    // Different nonce
-    sealer(&sk1, &n1, input, None, &mut dst_out_ct).unwrap();
-    assert!(opener(&sk1, &n2, &dst_out_ct, None, &mut dst_out_pt).is_err());
 }

--- a/src/test_framework/aead_interface.rs
+++ b/src/test_framework/aead_interface.rs
@@ -22,11 +22,12 @@
 
 #![allow(non_snake_case)]
 
+use crate::errors::UnknownCryptoError;
+use crate::{Public, Secret, generics::TypeSpec};
 use core::marker::PhantomData;
 
-#[cfg(feature = "safe_api")]
-use crate::errors::UnknownCryptoError;
-use crate::{Public, Secret, generics::TypeSpec, hazardous::stream::chacha20::CHACHA_BLOCKSIZE};
+#[cfg(any(feature = "safe_api", feature = "alloc"))]
+use crate::hazardous::stream::chacha20::CHACHA_BLOCKSIZE;
 use core::fmt::Debug;
 
 #[cfg(all(feature = "alloc", not(feature = "safe_api")))]
@@ -118,6 +119,7 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         Ok(())
     }
 
+    #[allow(unused_variables)] // input is not used on pure --no-default-features.
     pub fn run_all_tests(input: &[u8]) {
         Self::test_seal_zero_length_input_is_ok();
 

--- a/src/test_framework/aead_interface.rs
+++ b/src/test_framework/aead_interface.rs
@@ -574,7 +574,8 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         let diff_sk = Secret::<Aead::Key>::try_from(&skbytes).unwrap();
         let diff_tag = Aead::_seal_inplace(&diff_sk, &n, Some(&ad), &mut input).unwrap();
         assert_ne!(diff_tag, ref_tag);
-        if input.len() >= 4 { // avoid hitting equal for low input sizes randomly
+        if input.len() >= 4 {
+            // avoid hitting equal for low input sizes randomly
             assert_ne!(input, ref_ct);
         }
 
@@ -583,7 +584,8 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         let diff_n = Public::<Aead::Nonce>::try_from(&nbytes).unwrap();
         let diff_tag = Aead::_seal_inplace(&sk, &diff_n, Some(&ad), &mut input).unwrap();
         assert_ne!(diff_tag, ref_tag);
-        if input.len() >= 4 { // avoid hitting equal for low input sizes randomly
+        if input.len() >= 4 {
+            // avoid hitting equal for low input sizes randomly
             assert_ne!(input, ref_ct);
         }
 

--- a/src/test_framework/aead_interface.rs
+++ b/src/test_framework/aead_interface.rs
@@ -574,7 +574,7 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         let diff_sk = Secret::<Aead::Key>::try_from(&skbytes).unwrap();
         let diff_tag = Aead::_seal_inplace(&diff_sk, &n, Some(&ad), &mut input).unwrap();
         assert_ne!(diff_tag, ref_tag);
-        if input.len() >= 4 {
+        if input.len() >= 4 { // avoid hitting equal for low input sizes randomly
             assert_ne!(input, ref_ct);
         }
 
@@ -583,7 +583,7 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         let diff_n = Public::<Aead::Nonce>::try_from(&nbytes).unwrap();
         let diff_tag = Aead::_seal_inplace(&sk, &diff_n, Some(&ad), &mut input).unwrap();
         assert_ne!(diff_tag, ref_tag);
-        if input.len() >= 4 {
+        if input.len() >= 4 { // avoid hitting equal for low input sizes randomly
             assert_ne!(input, ref_ct);
         }
 

--- a/src/test_framework/aead_interface.rs
+++ b/src/test_framework/aead_interface.rs
@@ -574,7 +574,7 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         let diff_sk = Secret::<Aead::Key>::try_from(&skbytes).unwrap();
         let diff_tag = Aead::_seal_inplace(&diff_sk, &n, Some(&ad), &mut input).unwrap();
         assert_ne!(diff_tag, ref_tag);
-        if !input.is_empty() {
+        if input.len() >= 4 {
             assert_ne!(input, ref_ct);
         }
 
@@ -583,7 +583,7 @@ impl<Aead: TestableAead, const KS: usize, const NS: usize, const TS: usize>
         let diff_n = Public::<Aead::Nonce>::try_from(&nbytes).unwrap();
         let diff_tag = Aead::_seal_inplace(&sk, &diff_n, Some(&ad), &mut input).unwrap();
         assert_ne!(diff_tag, ref_tag);
-        if !input.is_empty() {
+        if input.len() >= 4 {
             assert_ne!(input, ref_ct);
         }
 

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -20,294 +20,257 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#![allow(non_snake_case)]
-
-#[cfg(feature = "safe_api")]
 use crate::errors::UnknownCryptoError;
+use core::marker::PhantomData;
 
-#[cfg(test)]
-#[cfg(feature = "safe_api")]
-pub trait TestingRandom {
-    /// Randomly generate self.
-    fn gen_new() -> Self;
+#[cfg(all(feature = "alloc", not(feature = "safe_api")))]
+use alloc::vec;
+
+pub trait TestableStreamCipher: Sized + Clone {
+    fn _new(sk: &[u8], n: &[u8]) -> Self;
+
+    #[cfg(test)]
+    #[cfg(feature = "safe_api")]
+    fn _random() -> Self;
+
+    fn _next_producible(&self) -> Result<(), UnknownCryptoError>;
+
+    fn _keystream_remaining(&self) -> u64;
+
+    fn _is_exhausted(&self) -> bool;
+
+    fn _set_position(&mut self, blockctr: u32);
+
+    fn _position(&self) -> u32;
+
+    fn _xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError>;
 }
 
-#[cfg(feature = "safe_api")]
-/// Test runner for stream ciphers.
-pub fn StreamCipherTestRunner<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: Encryptor,
-    decryptor: Decryptor,
-    key: Key,
-    nonce: Nonce,
-    counter: u32,
-    input: &[u8],
-    expected_ct: Option<&[u8]>,
-) where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    if !input.is_empty() {
-        encrypt_decrypt_out_length(&encryptor, &decryptor, &key, &nonce, input);
-        encrypt_decrypt_equals_expected(
-            &encryptor,
-            &decryptor,
-            &key,
-            &nonce,
-            counter,
-            input,
-            expected_ct,
+#[derive(Debug)]
+pub struct StreamcipherTester<SC: TestableStreamCipher> {
+    ctx: PhantomData<SC>,
+}
+
+impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
+    pub fn run_tests<const BS: usize, const MAX_POSITION: u32>(
+        sk: &[u8],
+        n: &[u8],
+        plaintext: Option<&[u8]>,
+        expected_ct: Option<&[u8]>,
+    ) {
+        if expected_ct.is_some() {
+            assert!(
+                plaintext.is_some(),
+                "cannot have expected ciphertext without plaintext"
+            );
+        }
+
+        let ctx = SC::_new(sk, n);
+
+        Self::next_producable_err_max::<MAX_POSITION>(&mut ctx.clone());
+        Self::xor_keystream_empty_ok(&mut ctx.clone());
+        Self::last_keystream_block_exhausts::<BS, MAX_POSITION>(&mut ctx.clone());
+
+        #[cfg(any(feature = "alloc", feature = "safe_api"))]
+        {
+            Self::return_err_if_next_overflows::<BS, MAX_POSITION>(&mut ctx.clone());
+            Self::xor_keystream_seek_ahead::<BS>(&mut ctx.clone());
+
+            if let Some(pt) = plaintext {
+                Self::xor_keystream_roundtrip(&mut ctx.clone(), pt);
+            }
+
+            if let (Some(pt), Some(expected)) = (plaintext, expected_ct) {
+                Self::xor_keystream_produces_expected(&mut ctx.clone(), pt, expected);
+            }
+        }
+
+        #[cfg(all(feature = "safe_api", test))]
+        Self::test_diff_params_diff_output();
+    }
+
+    /// Given an input length `a` find out how many times
+    /// the initial counter on encrypt()/decrypt() would
+    /// increase.
+    fn counter_increase_times(a: f32) -> u32 {
+        // Otherwise a overflowing subtraction would happen
+        if a <= 64f32 {
+            return 0;
+        }
+
+        let check_with_floor = (a / 64f32).floor();
+        let actual = a / 64f32;
+
+        assert!(actual >= check_with_floor);
+        // Subtract one because the first 64 in length
+        // the counter does not increase
+        if actual > check_with_floor {
+            (actual.ceil() as u32) - 1
+        } else {
+            (actual as u32) - 1
+        }
+    }
+
+    fn xor_keystream_empty_ok(ctx: &mut SC) {
+        assert!(ctx._xor_keystream_into(&mut [0u8; 0]).is_ok());
+    }
+
+    fn next_producable_err_max<const MAX: u32>(ctx: &mut SC) {
+        ctx._set_position(MAX - 2);
+        assert!(ctx._next_producible().is_ok());
+        ctx._set_position(MAX - 1);
+        assert!(ctx._next_producible().is_ok());
+        ctx._set_position(MAX);
+        assert!(ctx._next_producible().is_err());
+    }
+
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    fn xor_keystream_roundtrip(ctx: &mut SC, input: &[u8]) {
+        assert_eq!(ctx._position(), 0);
+        let mut inputdst = input.to_vec();
+        ctx._xor_keystream_into(&mut inputdst).unwrap();
+
+        if !input.is_empty() {
+            assert_ne!(&inputdst, &input);
+        }
+
+        ctx._set_position(0);
+        ctx._xor_keystream_into(&mut inputdst).unwrap();
+        assert_eq!(&inputdst, &input);
+    }
+
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    fn xor_keystream_produces_expected(ctx: &mut SC, pt: &[u8], expected: &[u8]) {
+        let mut ct_actual = pt.to_vec();
+        let mut pt_actual = expected.to_vec();
+        assert_eq!(ct_actual.len(), pt_actual.len());
+
+        let mut enc_ctx = ctx.clone();
+        let mut dec_ctx = ctx.clone();
+        assert_eq!(enc_ctx._position(), 0);
+        assert_eq!(dec_ctx._position(), 0);
+
+        enc_ctx._xor_keystream_into(&mut ct_actual).unwrap();
+        dec_ctx._xor_keystream_into(&mut pt_actual).unwrap();
+
+        assert_eq!(ct_actual, expected);
+        assert_eq!(pt_actual, pt);
+
+        assert_eq!(
+            Self::counter_increase_times(ct_actual.len() as f32),
+            enc_ctx._position()
+        );
+        assert_eq!(
+            Self::counter_increase_times(pt_actual.len() as f32),
+            dec_ctx._position()
         );
     }
 
-    encrypt_decrypt_input_empty(&encryptor, &decryptor, &key, &nonce);
-    initial_counter_overflow_err(&encryptor, &decryptor, &key, &nonce);
-    initial_counter_max_ok(&encryptor, &decryptor, &key, &nonce);
-}
+    fn last_keystream_block_exhausts<const BS: usize, const MAX: u32>(ctx: &mut SC) {
+        ctx._set_position(MAX);
+        assert!(!ctx._is_exhausted());
 
-#[cfg(feature = "safe_api")]
-/// Given an input length `a` find out how many times
-/// the initial counter on encrypt()/decrypt() would
-/// increase.
-fn counter_increase_times(a: f32) -> u32 {
-    // Otherwise a overflowing subtraction would happen
-    if a <= 64f32 {
-        return 0;
+        let mut block = [123u8; BS];
+
+        // OK: Generate the very last keystream block.
+        let prepos = ctx._position();
+        assert!(ctx._xor_keystream_into(&mut block).is_ok());
+        // (internally the streampos hasn't moved because it would wrap-around)
+        assert_eq!(prepos, ctx._position());
+        assert!(ctx._is_exhausted());
+        assert!(ctx._next_producible().is_err());
+        assert_eq!(ctx._keystream_remaining(), 0);
+
+        // ERR: Generate the last block again, even with BS size dst.
+        assert!(ctx._xor_keystream_into(&mut block).is_err());
+        assert_eq!(prepos, ctx._position());
+        assert!(ctx._is_exhausted());
+        assert!(ctx._next_producible().is_err());
+        assert_eq!(ctx._keystream_remaining(), 0);
+
+        // Should not be recoverable from exhausted state even with position.
+        ctx._set_position(0);
+        assert!(ctx._xor_keystream_into(&mut block).is_err());
+        assert!(ctx._is_exhausted());
+        assert!(ctx._next_producible().is_err()); // should also check self.exhausted
+        assert_eq!(ctx._keystream_remaining(), 0);
     }
 
-    let check_with_floor = (a / 64f32).floor();
-    let actual = a / 64f32;
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    fn return_err_if_next_overflows<const BS: usize, const MAX: u32>(ctx: &mut SC) {
+        ctx._set_position(MAX);
+        assert!(!ctx._is_exhausted());
 
-    assert!(actual >= check_with_floor);
-    // Subtract one because the first 64 in length
-    // the counter does not increase
-    if actual > check_with_floor {
-        (actual.ceil() as u32) - 1
-    } else {
-        (actual as u32) - 1
-    }
-}
+        let mut block = vec![123u8; BS + 8];
+        assert!(ctx._xor_keystream_into(&mut block).is_err());
+        // Generating the last block exhausted
+        assert!(ctx._is_exhausted());
 
-#[cfg(feature = "safe_api")]
-fn return_if_counter_will_overflow<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-    key: &Key,
-    nonce: &Nonce,
-    counter: u32,
-    input: &[u8],
-) -> bool
-where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    assert!(!input.is_empty());
-    let mut dst_out = vec![0u8; input.len()];
-
-    // Overflow will occur and the operation should fail
-    let enc_res = encryptor(key, nonce, counter, &[0u8; 0], &mut dst_out).is_err();
-    let dec_res = decryptor(key, nonce, counter, &[0u8; 0], &mut dst_out).is_err();
-
-    enc_res && dec_res
-}
-
-#[cfg(feature = "safe_api")]
-fn encrypt_decrypt_input_empty<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-    key: &Key,
-    nonce: &Nonce,
-) where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    let mut dst_out = [0u8; 64];
-    assert!(encryptor(key, nonce, 0, &[0u8; 0], &mut dst_out).is_err());
-    assert!(decryptor(key, nonce, 0, &[0u8; 0], &mut dst_out).is_err());
-}
-
-#[cfg(feature = "safe_api")]
-fn encrypt_decrypt_out_length<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-    key: &Key,
-    nonce: &Nonce,
-    input: &[u8],
-) where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    assert!(!input.is_empty());
-
-    let mut dst_out_empty = vec![0u8; 0];
-    assert!(encryptor(key, nonce, 0, input, &mut dst_out_empty).is_err());
-    assert!(decryptor(key, nonce, 0, input, &mut dst_out_empty).is_err());
-
-    let mut dst_out_less = vec![0u8; input.len() - 1];
-    assert!(encryptor(key, nonce, 0, input, &mut dst_out_less).is_err());
-    assert!(decryptor(key, nonce, 0, input, &mut dst_out_less).is_err());
-
-    let mut dst_out_exact = vec![0u8; input.len()];
-    assert!(encryptor(key, nonce, 0, input, &mut dst_out_exact).is_ok());
-    assert!(decryptor(key, nonce, 0, input, &mut dst_out_exact).is_ok());
-
-    let mut dst_out_greater = vec![0u8; input.len() + 1];
-    assert!(encryptor(key, nonce, 0, input, &mut dst_out_greater).is_ok());
-    assert!(decryptor(key, nonce, 0, input, &mut dst_out_greater).is_ok());
-}
-
-#[cfg(feature = "safe_api")]
-/// Test that encrypting and decrypting produces expected plaintext/ciphertext.
-fn encrypt_decrypt_equals_expected<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-    key: &Key,
-    nonce: &Nonce,
-    counter: u32,
-    input: &[u8],
-    expected_ct: Option<&[u8]>,
-) where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    assert!(!input.is_empty());
-
-    // Check if the counter would overflow. If yes, ensure that both encryptor and
-    // decryptor returned errors.
-    if counter_increase_times(input.len() as f32)
-        .checked_add(counter)
-        .is_none()
-    {
-        assert!(return_if_counter_will_overflow(
-            encryptor, decryptor, key, nonce, counter, input
-        ));
-
-        return;
+        // the last possible block is produced and acutally written to output
+        assert_ne!(&block[..BS], &[123u8; BS]);
+        // the last bytes are left untouched
+        assert_eq!(&block[BS..], &[123u8; 8]);
     }
 
-    let mut dst_out_ct = vec![0u8; input.len()];
-    encryptor(key, nonce, counter, input, &mut dst_out_ct).unwrap();
-    if let Some(expected_result) = expected_ct {
-        assert_eq!(expected_result, &dst_out_ct[..]);
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    fn xor_keystream_seek_ahead<const BS: usize>(ctx: &mut SC) {
+        let mut blocks = vec![0u8; BS * 10];
+
+        ctx._set_position(0);
+        ctx._xor_keystream_into(&mut blocks).unwrap();
+        assert_eq!(ctx._position(), 10);
+
+        ctx._set_position(0);
+        let mut block = [0u8; BS];
+        ctx._xor_keystream_into(&mut block).unwrap();
+        assert_eq!(&block, &blocks[..BS]);
+        assert_eq!(ctx._position(), 1);
+
+        ctx._set_position(1);
+        let mut block = [0u8; BS];
+        ctx._xor_keystream_into(&mut block).unwrap();
+        assert_eq!(&block, &blocks[BS..BS * 2]);
+        assert_eq!(ctx._position(), 2);
+
+        ctx._set_position(2);
+        let mut block = [0u8; BS];
+        ctx._xor_keystream_into(&mut block).unwrap();
+        assert_eq!(&block, &blocks[BS * 2..BS * 3]);
+        assert_eq!(ctx._position(), 3);
+
+        ctx._set_position(9);
+        let mut block = [0u8; BS];
+        ctx._xor_keystream_into(&mut block).unwrap();
+        assert_eq!(&block, &blocks[blocks.len() - BS..]);
+        assert_eq!(ctx._position(), 10);
     }
 
-    let mut dst_out_pt = vec![0u8; input.len()];
-    decryptor(key, nonce, counter, &dst_out_ct, &mut dst_out_pt).unwrap();
-    assert_eq!(input, &dst_out_pt[..]);
-    if let Some(expected_result) = expected_ct {
-        decryptor(key, nonce, counter, expected_result, &mut dst_out_pt).unwrap();
-        assert_eq!(input, &dst_out_pt[..]);
+    #[cfg(test)]
+    #[cfg(feature = "safe_api")]
+    /// Test that encrypting using different secret-key/nonce/initial-counter combinations yields different
+    /// ciphertexts.
+    fn test_diff_params_diff_output() {
+        let input = &[0u8; 16];
+
+        let mut ctx1 = SC::_random();
+        let mut ctx2 = SC::_random();
+
+        let mut dst1 = vec![0u8; input.len()];
+        let mut dst2 = vec![0u8; input.len()];
+
+        ctx1._xor_keystream_into(&mut dst1).unwrap();
+        ctx2._xor_keystream_into(&mut dst2).unwrap();
+        assert_ne!(&dst1, &input);
+        assert_ne!(&dst2, &input);
+        assert_ne!(&dst1, &dst2);
+
+        ctx1._set_position(0);
+        ctx2._set_position(0);
+
+        ctx1._xor_keystream_into(&mut dst1).unwrap();
+        ctx2._xor_keystream_into(&mut dst2).unwrap();
+        assert_eq!(&dst1, &input);
+        assert_eq!(&dst2, &input);
+        assert_eq!(&dst1, &dst2);
     }
-}
-
-#[cfg(feature = "safe_api")]
-/// Test that an initial counter will not overflow the internal.
-fn initial_counter_overflow_err<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-    key: &Key,
-    nonce: &Nonce,
-) where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    let mut dst_out = [0u8; 128];
-    assert!(
-        encryptor(
-            key,
-            nonce,
-            u32::MAX,
-            &[0u8; 65], //  CHACHA_BLOCKSIZE + 1 one to trigger internal block counter addition.
-            &mut dst_out
-        )
-        .is_err()
-    );
-    assert!(
-        decryptor(
-            key,
-            nonce,
-            u32::MAX,
-            &[0u8; 65], //  CHACHA_BLOCKSIZE + 1 one to trigger internal block counter addition.
-            &mut dst_out
-        )
-        .is_err()
-    );
-}
-
-#[cfg(feature = "safe_api")]
-/// Test that processing one block does not fail on the largest possible initial block counter.
-fn initial_counter_max_ok<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-    key: &Key,
-    nonce: &Nonce,
-) where
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    let mut dst_out = [0u8; 64];
-    assert!(
-        encryptor(
-            key,
-            nonce,
-            u32::MAX,
-            &[0u8; 64], // Only needs to process one keystream
-            &mut dst_out
-        )
-        .is_ok()
-    );
-    assert!(
-        decryptor(
-            key,
-            nonce,
-            u32::MAX,
-            &[0u8; 64], // Only needs to process one keystream
-            &mut dst_out
-        )
-        .is_ok()
-    );
-}
-
-#[cfg(test)]
-#[cfg(feature = "safe_api")]
-/// Test that encrypting using different secret-key/nonce/initial-counter combinations yields different
-/// ciphertexts.
-pub fn test_diff_params_diff_output<Encryptor, Decryptor, Key, Nonce>(
-    encryptor: &Encryptor,
-    decryptor: &Decryptor,
-) where
-    Key: TestingRandom + PartialEq<Key>,
-    Nonce: TestingRandom + PartialEq<Nonce>,
-    Encryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-    Decryptor: Fn(&Key, &Nonce, u32, &[u8], &mut [u8]) -> Result<(), UnknownCryptoError>,
-{
-    let input = &[0u8; 16];
-
-    let sk1 = Key::gen_new();
-    let sk2 = Key::gen_new();
-    assert!(sk1 != sk2);
-
-    let n1 = Nonce::gen_new();
-    let n2 = Nonce::gen_new();
-    assert!(n1 != n2);
-
-    let c1 = 0u32;
-    let c2 = 1u32;
-
-    let mut dst_out_ct = vec![0u8; input.len()];
-    let mut dst_out_pt = vec![0u8; input.len()];
-
-    // Different secret key
-    encryptor(&sk1, &n1, c1, input, &mut dst_out_ct).unwrap();
-    decryptor(&sk2, &n1, c1, &dst_out_ct, &mut dst_out_pt).unwrap();
-    assert_ne!(&dst_out_pt[..], input);
-
-    // Different nonce
-    encryptor(&sk1, &n1, c1, input, &mut dst_out_ct).unwrap();
-    decryptor(&sk1, &n2, c1, &dst_out_ct, &mut dst_out_pt).unwrap();
-    assert_ne!(&dst_out_pt[..], input);
-
-    // Different initial counter
-    encryptor(&sk1, &n1, c1, input, &mut dst_out_ct).unwrap();
-    decryptor(&sk1, &n1, c2, &dst_out_ct, &mut dst_out_pt).unwrap();
-    assert_ne!(&dst_out_pt[..], input);
 }

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -89,6 +89,7 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         Self::test_diff_params_diff_output();
     }
 
+    #[cfg(feature = "safe_api")]
     /// Given an input length `a` find out how many times
     /// the initial counter on encrypt()/decrypt() would
     /// increase.
@@ -139,7 +140,7 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         assert_eq!(&inputdst, &input);
     }
 
-    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    #[cfg(feature = "safe_api")]
     fn xor_keystream_produces_expected(ctx: &mut SC, pt: &[u8], expected: &[u8]) {
         let mut ct_actual = pt.to_vec();
         let mut pt_actual = expected.to_vec();

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::errors::UnknownCryptoError;
+use crate::{errors::UnknownCryptoError, hazardous::stream::chacha20::CHACHA_BLOCKSIZE};
 use core::marker::PhantomData;
 
 #[cfg(all(feature = "alloc", not(feature = "safe_api")))]
@@ -67,7 +67,7 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
 
         let ctx = SC::_new(sk, n);
 
-        Self::next_producable_err_max::<MAX_POSITION>(&mut ctx.clone());
+        Self::next_producable_ok_max::<MAX_POSITION>(&mut ctx.clone());
         Self::xor_keystream_empty_ok(&mut ctx.clone());
         Self::last_keystream_block_exhausts::<BS, MAX_POSITION>(&mut ctx.clone());
 
@@ -119,12 +119,17 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         assert!(ctx._xor_keystream_into(&mut [0u8; 0]).is_ok());
     }
 
-    fn next_producable_err_max<const MAX: u32>(ctx: &mut SC) {
+    fn next_producable_ok_max<const MAX: u32>(ctx: &mut SC) {
         ctx._set_position(MAX - 2);
         assert!(ctx._next_producible().is_ok());
         ctx._set_position(MAX - 1);
         assert!(ctx._next_producible().is_ok());
         ctx._set_position(MAX);
+        assert!(ctx._next_producible().is_ok());
+        // only after keystream_block() has generated the last
+        // block is the state exhausted and cannot produce any more.
+        let mut block = [0u8; CHACHA_BLOCKSIZE];
+        ctx._xor_keystream_into(&mut block).unwrap();
         assert!(ctx._next_producible().is_err());
     }
 

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -79,7 +79,10 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
             if let Some(pt) = plaintext {
                 Self::xor_keystream_roundtrip(&mut ctx.clone(), pt);
             }
+        }
 
+        #[cfg(feature = "safe_api")]
+        {
             if let (Some(pt), Some(expected)) = (plaintext, expected_ct) {
                 Self::xor_keystream_produces_expected(&mut ctx.clone(), pt, expected);
             }

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -25,6 +25,8 @@ use core::marker::PhantomData;
 
 #[cfg(all(feature = "alloc", not(feature = "safe_api")))]
 use alloc::vec;
+#[cfg(all(feature = "alloc", not(feature = "safe_api")))]
+use alloc::vec::Vec;
 
 pub trait TestableStreamCipher: Sized + Clone {
     const MAX_KEYSTREAM_BYTES: u64;

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -75,6 +75,8 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         {
             Self::return_err_if_next_overflows::<BS, MAX_POSITION>(&mut ctx.clone());
             Self::xor_keystream_seek_ahead::<BS>(&mut ctx.clone());
+            Self::test_xor_keystream_non_blocksize_aligned::<BS>(&mut ctx.clone());
+            Self::test_xor_keystream_last_two_full_blocks::<BS, MAX_POSITION>(&mut ctx.clone());
 
             if let Some(pt) = plaintext {
                 Self::xor_keystream_roundtrip(&mut ctx.clone(), pt);
@@ -281,5 +283,86 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         assert_eq!(&dst1, &input);
         assert_eq!(&dst2, &input);
         assert_eq!(&dst1, &dst2);
+    }
+
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    fn test_xor_keystream_last_two_full_blocks<const BS: usize, const MAX: u32>(ctx: &mut SC) {
+        assert_eq!(ctx._position(), 0);
+        assert!(!ctx._is_exhausted());
+
+        // Use u32::MAX to fill the last half block
+        let mut ctx = ctx.clone();
+        ctx._set_position(MAX - 1);
+        let mut twoblocks_min = vec![0u8; (MAX + (MAX / 2)) as usize];
+        assert!(ctx._xor_keystream_into(&mut twoblocks_min).is_ok());
+        assert!(ctx._is_exhausted());
+        assert_eq!(ctx._keystream_remaining(), 0);
+
+        // Use u32::MAX to fill the full last blocks
+        let mut ctx = ctx.clone();
+        ctx._set_position(MAX - 1);
+        let mut twoblocks_mid = vec![0u8; (MAX * 2) as usize];
+        assert!(ctx._xor_keystream_into(&mut twoblocks_mid).is_ok());
+        assert!(ctx._is_exhausted());
+        assert_eq!(ctx._keystream_remaining(), 0);
+
+        // ERR: Do not move past two full blocks
+        let mut ctx = ctx.clone();
+        ctx._set_position(u32::MAX - 1);
+        let mut twoblocks_max = vec![0u8; ((MAX * 2) + 1) as usize];
+        assert!(ctx._xor_keystream_into(&mut twoblocks_max).is_err());
+        assert!(ctx._is_exhausted());
+        assert_eq!(ctx._keystream_remaining(), 0);
+
+        assert_eq!(&twoblocks_min, &twoblocks_mid[..twoblocks_min.len()]);
+        assert_eq!(&twoblocks_mid, &twoblocks_max[..twoblocks_mid.len()]);
+        assert_eq!(twoblocks_max[twoblocks_max.len() - 1], 0);
+    }
+
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    /// This test should be identical in intention to the
+    /// `StreamingContextConsistencyTester::incremental_processing_with_leftover()`
+    fn test_xor_keystream_non_blocksize_aligned<const BS: usize>(ctx: &mut SC) {
+        assert_eq!(ctx._position(), 0);
+
+        for len in 0..BS * 4 {
+            let mut data = vec![0u8; len];
+            let mut state = ctx.clone();
+            let mut other_data: Vec<u8> = Vec::new();
+
+            other_data.extend_from_slice(&data);
+            state._xor_keystream_into(&mut data).unwrap();
+
+            if data.len() > BS {
+                let data_prelen = data.len();
+                data.extend_from_slice(b"");
+                state._xor_keystream_into(&mut data[data_prelen..]).unwrap();
+                other_data.extend_from_slice(b"");
+            }
+            if data.len() > BS * 2 {
+                let data_prelen = data.len();
+                data.extend_from_slice(b"Extra");
+                state._xor_keystream_into(&mut data[data_prelen..]).unwrap();
+                other_data.extend_from_slice(b"Extra");
+            }
+            if data.len() > BS * 3 {
+                let data_prelen = data.len();
+                data.extend_from_slice(&[0u8; 256]);
+                state._xor_keystream_into(&mut data[data_prelen..]).unwrap();
+                other_data.extend_from_slice(&[0u8; 256]);
+            }
+
+            let mut one_shot = ctx.clone();
+            one_shot._xor_keystream_into(&mut other_data).unwrap();
+
+            assert_eq!(data, other_data);
+            assert_eq!(one_shot._is_exhausted(), one_shot._is_exhausted());
+            assert_eq!(one_shot._position(), one_shot._position());
+            assert_eq!(
+                one_shot._keystream_remaining(),
+                one_shot._keystream_remaining()
+            );
+            assert_eq!(one_shot._is_exhausted(), one_shot._is_exhausted());
+        }
     }
 }

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -87,6 +87,7 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
             Self::xor_keystream_seek_ahead::<BS>(&mut ctx.clone());
             Self::test_xor_keystream_non_blocksize_aligned::<BS>(&mut ctx.clone());
             Self::test_xor_keystream_last_two_full_blocks::<BS, MAX_POSITION>(&mut ctx.clone());
+            Self::test_byte_position_at_exhaust::<BS, MAX_POSITION>(&mut ctx.clone());
 
             if let Some(pt) = plaintext {
                 Self::xor_keystream_roundtrip(&mut ctx.clone(), pt);
@@ -161,7 +162,8 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         let mut inputdst = input.to_vec();
         ctx._xor_keystream_into(&mut inputdst).unwrap();
 
-        if !input.is_empty() {
+        if !input.is_empty() && input.len() > 4 {
+            // no random collisions on low-length things
             assert_ne!(&inputdst, &input);
         }
 
@@ -408,5 +410,63 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
                 assert_eq!(one_shot._byte_position() as usize, 0);
             }
         }
+    }
+
+    #[cfg(any(feature = "alloc", feature = "safe_api"))]
+    fn test_byte_position_at_exhaust<const BS: usize, const MAX: u32>(ctx: &mut SC) {
+        let mut wctx = ctx.clone();
+        wctx._set_position(MAX);
+        let mut block = [0u8; BS];
+        wctx._xor_keystream_into(&mut block).unwrap();
+
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), 0);
+        assert_eq!(wctx._byte_position(), SC::MAX_KEYSTREAM_BYTES);
+        assert_eq!(
+            wctx._byte_position() + wctx._keystream_remaining(),
+            SC::MAX_KEYSTREAM_BYTES
+        );
+
+        let mut wctx = ctx.clone();
+        wctx._set_position(MAX);
+        assert_eq!(
+            wctx._byte_position(),
+            SC::MAX_KEYSTREAM_BYTES - CHACHA_BLOCKSIZE as u64
+        );
+        let mut block = [0u8; 41];
+        wctx._xor_keystream_into(&mut block).unwrap();
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), CHACHA_BLOCKSIZE as u64 - 41);
+        assert_eq!(wctx._byte_position(), SC::MAX_KEYSTREAM_BYTES - 23);
+
+        let mut blockrem = [0u8; 23];
+        wctx._xor_keystream_into(&mut blockrem).unwrap();
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), 0);
+        assert_eq!(wctx._byte_position(), SC::MAX_KEYSTREAM_BYTES);
+
+        let mut wctx = ctx.clone();
+        wctx._set_byte_position(SC::MAX_KEYSTREAM_BYTES - 1)
+            .unwrap();
+        let mut byte = [0u8; 1];
+        wctx._xor_keystream_into(&mut byte).unwrap();
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), 0);
+        assert_eq!(wctx._byte_position(), SC::MAX_KEYSTREAM_BYTES);
+
+        let mut wctx = ctx.clone();
+        wctx._set_position(MAX - 1);
+        let mut blocks = vec![0u8; BS + BS / 2];
+        wctx._xor_keystream_into(&mut blocks).unwrap();
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), (BS / 2) as u64);
+        assert_eq!(
+            wctx._byte_position(),
+            SC::MAX_KEYSTREAM_BYTES - (BS / 2) as u64
+        );
+        assert_eq!(
+            wctx._byte_position() + wctx._keystream_remaining(),
+            SC::MAX_KEYSTREAM_BYTES
+        );
     }
 }

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -164,7 +164,7 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         ctx._set_position(0);
         ctx._xor_keystream_into(&mut inputdst).unwrap();
         assert_eq!(&inputdst, &input);
-        assert_eq!(ctx._byte_position() as usize, input.len() - 1);
+        assert_eq!(ctx._byte_position() as usize, input.len());
     }
 
     #[cfg(feature = "safe_api")]
@@ -313,7 +313,8 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         let mut twoblocks_min = vec![0u8; BS + (BS / 2)];
         assert!(wctx._xor_keystream_into(&mut twoblocks_min).is_ok());
         assert!(wctx._is_exhausted());
-        assert_eq!(wctx._keystream_remaining(), 0);
+        // Still has 32 bytes leftover from the last block.
+        assert_eq!(wctx._keystream_remaining(), (BS / 2) as u64);
 
         // Use u32::MAX to fill the full last blocks
         let mut wctx = ctx.clone();
@@ -389,8 +390,8 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
             );
 
             if !data.is_empty() {
-                assert_eq!(state._byte_position() as usize, data.len() - 1);
-                assert_eq!(one_shot._byte_position() as usize, other_data.len() - 1);
+                assert_eq!(state._byte_position() as usize, data.len());
+                assert_eq!(one_shot._byte_position() as usize, other_data.len());
             } else {
                 assert_eq!(state._byte_position() as usize, 0);
                 assert_eq!(one_shot._byte_position() as usize, 0);

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -135,6 +135,8 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
 
     fn set_bytes_pos_err_past_max<const MAX_BYTES: u64>(ctx: &mut SC) {
         assert!(ctx._set_byte_position(MAX_BYTES + 1).is_err());
+        assert!(ctx._set_byte_position(MAX_BYTES).is_err()); // 0-indexed
+        assert!(ctx._set_byte_position(MAX_BYTES - 1).is_ok());
     }
 
     fn next_producable_ok_max<const MAX: u32>(ctx: &mut SC) {
@@ -315,6 +317,13 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         assert!(wctx._is_exhausted());
         // Still has 32 bytes leftover from the last block.
         assert_eq!(wctx._keystream_remaining(), (BS / 2) as u64);
+        let mut consume_leftover = vec![0u8; BS / 2];
+        assert!(wctx._xor_keystream_into(&mut consume_leftover).is_ok());
+        assert!(wctx._is_exhausted());
+        // Consume the leftover keystream of the last block.
+        assert_eq!(wctx._keystream_remaining(), 0);
+        let mut err = [0u8; 1];
+        assert!(wctx._xor_keystream_into(&mut err).is_err());
 
         // Use u32::MAX to fill the full last blocks
         let mut wctx = ctx.clone();

--- a/src/test_framework/streamcipher_interface.rs
+++ b/src/test_framework/streamcipher_interface.rs
@@ -27,6 +27,8 @@ use core::marker::PhantomData;
 use alloc::vec;
 
 pub trait TestableStreamCipher: Sized + Clone {
+    const MAX_KEYSTREAM_BYTES: u64;
+
     fn _new(sk: &[u8], n: &[u8]) -> Self;
 
     #[cfg(test)]
@@ -41,7 +43,11 @@ pub trait TestableStreamCipher: Sized + Clone {
 
     fn _set_position(&mut self, blockctr: u32);
 
+    fn _set_byte_position(&mut self, pos: u64) -> Result<(), UnknownCryptoError>;
+
     fn _position(&self) -> u32;
+
+    fn _byte_position(&mut self) -> u64;
 
     fn _xor_keystream_into(&mut self, bytes: &mut [u8]) -> Result<(), UnknownCryptoError>;
 }
@@ -52,7 +58,7 @@ pub struct StreamcipherTester<SC: TestableStreamCipher> {
 }
 
 impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
-    pub fn run_tests<const BS: usize, const MAX_POSITION: u32>(
+    pub fn run_tests<const BS: usize, const MAX_POSITION: u32, const MAX_BYTES: u64>(
         sk: &[u8],
         n: &[u8],
         plaintext: Option<&[u8]>,
@@ -70,6 +76,8 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         Self::next_producable_ok_max::<MAX_POSITION>(&mut ctx.clone());
         Self::xor_keystream_empty_ok(&mut ctx.clone());
         Self::last_keystream_block_exhausts::<BS, MAX_POSITION>(&mut ctx.clone());
+        Self::bytes_pos_keystream_rem::<MAX_BYTES>(&mut ctx.clone());
+        Self::set_bytes_pos_err_past_max::<MAX_BYTES>(&mut ctx.clone());
 
         #[cfg(any(feature = "alloc", feature = "safe_api"))]
         {
@@ -121,6 +129,14 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         assert!(ctx._xor_keystream_into(&mut [0u8; 0]).is_ok());
     }
 
+    fn bytes_pos_keystream_rem<const MAX_BYTES: u64>(ctx: &mut SC) {
+        assert_eq!(ctx._keystream_remaining() + ctx._byte_position(), MAX_BYTES);
+    }
+
+    fn set_bytes_pos_err_past_max<const MAX_BYTES: u64>(ctx: &mut SC) {
+        assert!(ctx._set_byte_position(MAX_BYTES + 1).is_err());
+    }
+
     fn next_producable_ok_max<const MAX: u32>(ctx: &mut SC) {
         ctx._set_position(MAX - 2);
         assert!(ctx._next_producible().is_ok());
@@ -148,6 +164,7 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         ctx._set_position(0);
         ctx._xor_keystream_into(&mut inputdst).unwrap();
         assert_eq!(&inputdst, &input);
+        assert_eq!(ctx._byte_position() as usize, input.len() - 1);
     }
 
     #[cfg(feature = "safe_api")]
@@ -291,28 +308,28 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
         assert!(!ctx._is_exhausted());
 
         // Use u32::MAX to fill the last half block
-        let mut ctx = ctx.clone();
-        ctx._set_position(MAX - 1);
-        let mut twoblocks_min = vec![0u8; (MAX + (MAX / 2)) as usize];
-        assert!(ctx._xor_keystream_into(&mut twoblocks_min).is_ok());
-        assert!(ctx._is_exhausted());
-        assert_eq!(ctx._keystream_remaining(), 0);
+        let mut wctx = ctx.clone();
+        wctx._set_position(MAX - 1);
+        let mut twoblocks_min = vec![0u8; BS + (BS / 2)];
+        assert!(wctx._xor_keystream_into(&mut twoblocks_min).is_ok());
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), 0);
 
         // Use u32::MAX to fill the full last blocks
-        let mut ctx = ctx.clone();
-        ctx._set_position(MAX - 1);
-        let mut twoblocks_mid = vec![0u8; (MAX * 2) as usize];
-        assert!(ctx._xor_keystream_into(&mut twoblocks_mid).is_ok());
-        assert!(ctx._is_exhausted());
-        assert_eq!(ctx._keystream_remaining(), 0);
+        let mut wctx = ctx.clone();
+        wctx._set_position(MAX - 1);
+        let mut twoblocks_mid = vec![0u8; BS * 2];
+        assert!(wctx._xor_keystream_into(&mut twoblocks_mid).is_ok());
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), 0);
 
         // ERR: Do not move past two full blocks
-        let mut ctx = ctx.clone();
-        ctx._set_position(u32::MAX - 1);
-        let mut twoblocks_max = vec![0u8; ((MAX * 2) + 1) as usize];
-        assert!(ctx._xor_keystream_into(&mut twoblocks_max).is_err());
-        assert!(ctx._is_exhausted());
-        assert_eq!(ctx._keystream_remaining(), 0);
+        let mut wctx = ctx.clone();
+        wctx._set_position(u32::MAX - 1);
+        let mut twoblocks_max = vec![0u8; (BS * 2) + 1];
+        assert!(wctx._xor_keystream_into(&mut twoblocks_max).is_err());
+        assert!(wctx._is_exhausted());
+        assert_eq!(wctx._keystream_remaining(), 0);
 
         assert_eq!(&twoblocks_min, &twoblocks_mid[..twoblocks_min.len()]);
         assert_eq!(&twoblocks_mid, &twoblocks_max[..twoblocks_mid.len()]);
@@ -356,13 +373,28 @@ impl<SC: TestableStreamCipher> StreamcipherTester<SC> {
             one_shot._xor_keystream_into(&mut other_data).unwrap();
 
             assert_eq!(data, other_data);
-            assert_eq!(one_shot._is_exhausted(), one_shot._is_exhausted());
-            assert_eq!(one_shot._position(), one_shot._position());
+            assert_eq!(state._is_exhausted(), one_shot._is_exhausted());
+            assert_eq!(state._position(), one_shot._position());
             assert_eq!(
-                one_shot._keystream_remaining(),
+                state._keystream_remaining(),
                 one_shot._keystream_remaining()
             );
-            assert_eq!(one_shot._is_exhausted(), one_shot._is_exhausted());
+            assert_eq!(
+                state._keystream_remaining(),
+                SC::MAX_KEYSTREAM_BYTES - data.len() as u64,
+            );
+            assert_eq!(
+                one_shot._keystream_remaining(),
+                SC::MAX_KEYSTREAM_BYTES - other_data.len() as u64,
+            );
+
+            if !data.is_empty() {
+                assert_eq!(state._byte_position() as usize, data.len() - 1);
+                assert_eq!(one_shot._byte_position() as usize, other_data.len() - 1);
+            } else {
+                assert_eq!(state._byte_position() as usize, 0);
+                assert_eq!(one_shot._byte_position() as usize, 0);
+            }
         }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -34,6 +34,16 @@ macro_rules! xor_slices {
     };
 }
 
+#[inline(always)]
+/// xor_slices(src, destination): XOR src into destination slice.
+/// Uses iter() and .zip(), so it short-circuits on the slice that has
+/// the smallest length.
+pub(crate) fn xor_slices(src: &[u8], dst: &mut [u8]) {
+    for (inplace, selem) in dst.iter_mut().zip(src.iter()) {
+        *inplace ^= selem;
+    }
+}
+
 pub(crate) mod endianness;
 pub(crate) mod u32x4;
 pub(crate) mod u64x4;

--- a/src/util/u32x4.rs
+++ b/src/util/u32x4.rs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct U32x4(
     pub(crate) u32,
     pub(crate) u32,

--- a/tests/aead/mod.rs
+++ b/tests/aead/mod.rs
@@ -6,9 +6,10 @@ pub mod wycheproof_aead;
 
 use orion::errors::UnknownCryptoError;
 use orion::hazardous::aead::{
-    chacha20poly1305::{self, SecretKey},
-    xchacha20poly1305,
+    chacha20poly1305::{ChaCha20Poly1305, Nonce as IetfNonce, SecretKey},
+    xchacha20poly1305::{Nonce as XNonce, XChaCha20Poly1305},
 };
+use orion::hazardous::mac::poly1305::Tag;
 
 #[allow(clippy::too_many_arguments)]
 fn wycheproof_test_runner(
@@ -24,23 +25,43 @@ fn wycheproof_test_runner(
 ) -> Result<(), UnknownCryptoError> {
     let mut dst_ct_out = vec![0u8; input.len() + 16];
     let mut dst_pt_out = vec![0u8; input.len()];
+    let mut inplace_ct = input.to_vec();
+    let mut inplace_pt: Vec<u8>;
+    let inplace_tag: Tag;
 
     if result {
         let key = SecretKey::try_from(key)?;
 
         if is_ietf {
-            let nonce = chacha20poly1305::Nonce::try_from(nonce)?;
-            chacha20poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out)?;
-            chacha20poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out)?;
+            let nonce = IetfNonce::try_from(nonce)?;
+            ChaCha20Poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out)?;
+            ChaCha20Poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out)?;
+
+            inplace_tag = ChaCha20Poly1305::seal_inplace(&key, &nonce, Some(aad), &mut inplace_ct)?;
+            inplace_pt = inplace_ct.clone();
+            ChaCha20Poly1305::open_inplace(&key, &nonce, &inplace_tag, Some(aad), &mut inplace_pt)?;
         } else {
-            let nonce = xchacha20poly1305::Nonce::try_from(nonce)?;
-            xchacha20poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out)?;
-            xchacha20poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out)?;
+            let nonce = XNonce::try_from(nonce)?;
+            XChaCha20Poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out)?;
+            XChaCha20Poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out)?;
+
+            inplace_tag =
+                XChaCha20Poly1305::seal_inplace(&key, &nonce, Some(aad), &mut inplace_ct)?;
+            inplace_pt = inplace_ct.clone();
+            XChaCha20Poly1305::open_inplace(
+                &key,
+                &nonce,
+                &inplace_tag,
+                Some(aad),
+                &mut inplace_pt,
+            )?;
         }
 
         assert_eq!(dst_ct_out[..input.len()].as_ref(), output);
         assert_eq!(dst_ct_out[input.len()..].as_ref(), tag);
-        assert_eq!(dst_pt_out[..].as_ref(), input);
+        assert_eq!(inplace_ct.as_slice(), output);
+        assert_eq!(inplace_pt.as_slice(), input);
+        assert_eq!(inplace_tag.unprotected_as_ref(), tag);
     } else {
         // Tests that run here have a "invalid" flag set
         let key = match SecretKey::try_from(key) {
@@ -54,22 +75,38 @@ fn wycheproof_test_runner(
         let openres: Result<(), UnknownCryptoError>;
 
         if is_ietf {
-            let nonce = match chacha20poly1305::Nonce::try_from(nonce) {
+            let nonce = match IetfNonce::try_from(nonce) {
                 Ok(n) => n,
                 Err(UnknownCryptoError) => return Ok(()), // Invalid nonce size test
             };
 
-            sealres = chacha20poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out);
-            openres = chacha20poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out);
+            sealres = ChaCha20Poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out);
+            openres = ChaCha20Poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out);
+
+            // We don't check output of inplace API here. Equality between inplace and buffered is tested throughout the rest of the library.
+            // We cannot check openres for inplace, because the Tag isn't released on failure. But, due to the aforementioned equivalence,
+            // it is asserted that the sealres and sealres_inplace are also equivalent, and sufficient to indicate failure.
+            // It is not expected these two results should EVER mismatch.
+            let sealres_inplace =
+                ChaCha20Poly1305::seal_inplace(&key, &nonce, Some(aad), &mut inplace_ct);
+            assert_eq!(sealres.is_err(), sealres_inplace.is_err());
         } else {
-            let nonce = match xchacha20poly1305::Nonce::try_from(nonce) {
+            let nonce = match XNonce::try_from(nonce) {
                 Ok(n) => n,
                 Err(UnknownCryptoError) => return Ok(()), // Invalid nonce size test
             };
 
-            sealres = xchacha20poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out);
+            sealres = XChaCha20Poly1305::seal(&key, &nonce, input, Some(aad), &mut dst_ct_out);
             openres =
-                xchacha20poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out);
+                XChaCha20Poly1305::open(&key, &nonce, &dst_ct_out, Some(aad), &mut dst_pt_out);
+
+            // We don't check output of inplace API here. Equality between inplace and buffered is tested throughout the rest of the library.
+            // We cannot check openres for inplace, because the Tag isn't released on failure. But, due to the aforementioned equivalence,
+            // it is asserted that the sealres and sealres_inplace are also equivalent, and sufficient to indicate failure.
+            // It is not expected these two results should EVER mismatch.
+            let sealres_inplace =
+                XChaCha20Poly1305::seal_inplace(&key, &nonce, Some(aad), &mut inplace_ct);
+            assert_eq!(sealres.is_err(), sealres_inplace.is_err());
         }
 
         // Test case results may be invalid, but this does not mean both seal() and

--- a/tests/aead/other_xchacha20_poly1305.rs
+++ b/tests/aead/other_xchacha20_poly1305.rs
@@ -48,7 +48,7 @@ mod sodiumoxide_xchacha20_poly1305 {
         let mut dst_out_ct = vec![0u8; expected_ct.len()];
         let mut dst_out_pt = vec![0u8; plaintext.len()];
 
-        aead::xchacha20poly1305::seal(
+        aead::xchacha20poly1305::XChaCha20Poly1305::seal(
             &aead::xchacha20poly1305::SecretKey::try_from(&key).unwrap(),
             &aead::xchacha20poly1305::Nonce::try_from(&nonce).unwrap(),
             &plaintext,
@@ -67,7 +67,7 @@ mod sodiumoxide_xchacha20_poly1305 {
             expected_ct[plaintext.len()..].as_ref()
         );
 
-        aead::xchacha20poly1305::open(
+        aead::xchacha20poly1305::XChaCha20Poly1305::open(
             &aead::xchacha20poly1305::SecretKey::try_from(&key).unwrap(),
             &aead::xchacha20poly1305::Nonce::try_from(&nonce).unwrap(),
             &dst_out_ct,
@@ -95,7 +95,7 @@ mod wireguard_xchacha20_poly1305 {
         let mut dst_out_pt = vec![0u8; plaintext.len()];
 
         // These test vectors use empty ad parameter, see source.
-        aead::xchacha20poly1305::seal(
+        aead::xchacha20poly1305::XChaCha20Poly1305::seal(
             &aead::xchacha20poly1305::SecretKey::try_from(key).unwrap(),
             &aead::xchacha20poly1305::Nonce::try_from(nonce).unwrap(),
             plaintext,
@@ -114,7 +114,7 @@ mod wireguard_xchacha20_poly1305 {
             expected_ct[plaintext.len()..].as_ref()
         );
 
-        aead::xchacha20poly1305::open(
+        aead::xchacha20poly1305::XChaCha20Poly1305::open(
             &aead::xchacha20poly1305::SecretKey::try_from(key).unwrap(),
             &aead::xchacha20poly1305::Nonce::try_from(nonce).unwrap(),
             &dst_out_ct,

--- a/tests/aead/rfc_chacha20_poly1305.rs
+++ b/tests/aead/rfc_chacha20_poly1305.rs
@@ -109,7 +109,7 @@ mod rfc_aead_chacha20_poly1305 {
 
         let mut dst_out_pt = vec![0u8; ciphertext.len()];
 
-        aead::chacha20poly1305::open(
+        aead::chacha20poly1305::ChaCha20Poly1305::open(
             &aead::chacha20poly1305::SecretKey::try_from(&key).unwrap(),
             &aead::chacha20poly1305::Nonce::try_from(&nonce).unwrap(),
             &ct_plus_tag,

--- a/tests/stream/mod.rs
+++ b/tests/stream/mod.rs
@@ -3,10 +3,9 @@ pub mod rfc_chacha20;
 pub mod rfc_xchacha20;
 
 use chacha20::SecretKey;
-use orion::hazardous::stream::chacha20::CHACHA_KEYSIZE;
 use orion::hazardous::stream::chacha20::{self, IETF_CHACHA_NONCESIZE};
-use orion::hazardous::stream::xchacha20::{self, XCHACHA_NONCESIZE};
-use orion::test_framework::streamcipher_interface::StreamCipherTestRunner;
+use orion::hazardous::stream::chacha20::{CHACHA_KEYSIZE, ChaCha20};
+use orion::hazardous::stream::xchacha20::{self, XCHACHA_NONCESIZE, XChaCha20};
 
 pub fn chacha_test_runner(
     key: &[u8],
@@ -23,33 +22,37 @@ pub fn chacha_test_runner(
         return;
     }
 
-    let sk = SecretKey::try_from(key).unwrap();
+    let mut ct_actual = input.to_vec();
+    let mut pt_actual = output.to_vec();
+    assert_eq!(ct_actual.len(), pt_actual.len());
 
-    // Selecting variant based on nonce size
-    if nonce.len() == IETF_CHACHA_NONCESIZE {
-        let n = chacha20::Nonce::try_from(nonce).unwrap();
-        StreamCipherTestRunner(
-            chacha20::encrypt,
-            chacha20::decrypt,
-            sk,
-            n,
-            init_block_count,
-            input,
-            Some(output),
-        );
-    } else if nonce.len() == XCHACHA_NONCESIZE {
-        let n = xchacha20::Nonce::try_from(nonce).unwrap();
-        StreamCipherTestRunner(
-            xchacha20::encrypt,
-            xchacha20::decrypt,
-            sk,
-            n,
-            init_block_count,
-            input,
-            Some(output),
-        );
-    } else {
-        assert!(chacha20::Nonce::try_from(nonce).is_err());
-        assert!(xchacha20::Nonce::try_from(nonce).is_err());
+    let sk = SecretKey::try_from(key).unwrap();
+    match nonce.len() {
+        IETF_CHACHA_NONCESIZE => {
+            let n = chacha20::Nonce::try_from(nonce).unwrap();
+            let mut ctx = ChaCha20::new(&sk, &n);
+
+            ctx.set_position(init_block_count);
+            ctx.xor_keystream_into(&mut ct_actual).unwrap();
+            assert_eq!(ct_actual, output);
+            ctx.set_position(init_block_count);
+            ctx.xor_keystream_into(&mut pt_actual).unwrap();
+            assert_eq!(pt_actual, input);
+        }
+        XCHACHA_NONCESIZE => {
+            let n = xchacha20::Nonce::try_from(nonce).unwrap();
+            let mut ctx = XChaCha20::new(&sk, &n);
+
+            ctx.set_position(init_block_count);
+            ctx.xor_keystream_into(&mut ct_actual).unwrap();
+            assert_eq!(ct_actual, output);
+            ctx.set_position(init_block_count);
+            ctx.xor_keystream_into(&mut pt_actual).unwrap();
+            assert_eq!(pt_actual, input);
+        }
+        _ => {
+            assert!(chacha20::Nonce::try_from(nonce).is_err());
+            assert!(xchacha20::Nonce::try_from(nonce).is_err());
+        }
     }
 }


### PR DESCRIPTION
The following lists the motivations/justifications for the breaking changes of the APIs (which are listed in the CHANGELOG):

*`orion::hazardous::stream`*
While the current `encrypt()`/`decrypt()` functions can be used in theory for the same operations as what this new API offers, this approach is more ergonomic and aligns more with the actual design of a stream-cipher. This also makes it easier to use the instances for other purposes, such as RNG. It also provides more clear seeking/out-of-order API with `set_position()`.

*`orion::hazardous::aead`*
Again, the same functionality and this time under the same name, but under a struct. The reason this has been moved to a type is that it makes it much more adaptable across the rest of the crate for future additions. One example is the work on providing additional HPKE ciphersuits, where this right now means hardcoded AEAD.

The `seal_inplace()`/`open_inplace()` are offered to enable direct overwriting of plaintext data to avoid extra allocations and the need to handle zeroization of the original.
