### PR TITLE
`v0.18.0`: New feature `ct-test` for use in orion-dudect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Add support for ML-DSA (FIPS-204).
 - Add new high-level module `orion::signer` which provides post-quantum hedged ML-DSA-65 signature creation and verification.
 - `orion::utils::secure_rand_bytes()` no longer panics and propagates all errors.
+- Introduce a new feature `ct-test` which only is for testing internal constant-time logic.
 
 ### 0.17.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ safe_api = ["getrandom", "ct-codecs", "zeroize?/alloc"]
 alloc = ["zeroize?/alloc"]
 serde = ["dep:serde", "alloc"]
 experimental = []
+ct-test = []
 
 [dev-dependencies]
 hex = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@
 ### About
 Orion is a cryptography library written in pure Rust. It aims to provide easy and usable crypto while trying to minimize the use of unsafe code. You can read more about Orion in the [wiki](https://github.com/orion-rs/orion/wiki).
 
-Currently supports:
+### Supported algorithms
+
+#### PQ + PQ/T
+* **Signature schemes**: ML-DSA.
+* **KEM**: X-Wing, ML-KEM.
+* **HPKE**:
+    - X-Wing/(ML-KEM768, X25519), HKDF-SHA256, ChaCha20Poly1305
+    - X-Wing/(ML-KEM768, X25519), SHAKE256, ChaCha20Poly1305
+
+#### Other
 * **AEAD**: (X)ChaCha20-Poly1305.
 * **Hashing**: BLAKE3, BLAKE2b, SHA2, SHA3.
 * **XOF**: SHAKE128, SHAKE256.
@@ -12,12 +21,9 @@ Currently supports:
 * **ECDH**: X25519.
 * **MAC**: HMAC, Poly1305.
 * **Stream ciphers**: (X)ChaCha20.
-* **Signature schemes**: ML-DSA.
-* **KEM**: X-Wing, ML-KEM, DHKEM(X25519, HKDF-SHA256).
 * **HPKE**:
-    - X-Wing/(ML-KEM768, X25519), HKDF-SHA256, ChaCha20Poly1305
-    - X-Wing/(ML-KEM768, X25519), SHAKE256, ChaCha20Poly1305
     - DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305
+* **KEM**: DHKEM(X25519, HKDF-SHA256).
 
 Experimental support (with `experimental` feature enabled):
 * **Committing AEAD**: (X)ChaCha20-Poly1305-BLAKE2b.
@@ -42,6 +48,7 @@ MSRV may be changed at any point and will not be considered a SemVer breaking ch
 - `no_std`: Implicit feature that represents no heap allocations. Enabled by disabling default features and not selecting any additional features.
 - `zeroize`: Toggles whether sensitive key material is zeroized internally. Enabled by default.
 - `experimental`: These APIs may contain breaking changes in any non SemVer-breaking crate releases.
+- `ct-test`: Exposes some internal functionality that is only relevant for test (used in `orion-dudect`).
 
 More detailed explanation of the features in the [wiki](https://github.com/orion-rs/orion/wiki/Crate-features).
 

--- a/src/hazardous/dsa/ml_dsa/internal/fe.rs
+++ b/src/hazardous/dsa/ml_dsa/internal/fe.rs
@@ -134,7 +134,7 @@ pub const NEG_ZETA_ALL_MONT: [MontFactor; 256] = mont_factor_tables(&NEG_ZETA_AL
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 /// Element in the field Z_q.
-pub struct FieldElement<D: Domain>(pub(crate) u32, PhantomData<D>);
+pub struct FieldElement<D: Domain>(pub u32, PhantomData<D>);
 
 #[cfg(feature = "zeroize")]
 impl<D: Domain> Zeroize for FieldElement<D> {
@@ -145,12 +145,12 @@ impl<D: Domain> Zeroize for FieldElement<D> {
 
 /// Specific routines for non-Montgomery domain field elements.
 impl FieldElement<Standard> {
-    pub(crate) const fn new(n: u32) -> Self {
+    pub const fn new(n: u32) -> Self {
         debug_assert!(n < DILITHIUM_Q);
         Self(n, PhantomData)
     }
 
-    pub(crate) const fn power2round<P: MlDsaParameters>(&self) -> (u32, u32) {
+    pub const fn power2round<P: MlDsaParameters>(&self) -> (u32, u32) {
         debug_assert!(self.0 < DILITHIUM_Q);
         let r1 = (self.0.overflowing_add((1 << (P::D - 1)) - 1).0) >> P::D;
         let r0 = self.0.overflowing_add(DILITHIUM_Q - (r1 << P::D)).0;
@@ -158,7 +158,7 @@ impl FieldElement<Standard> {
         (r1, conditional_sub_u32(r0))
     }
 
-    pub(crate) fn is_outside_bound(&self, bound: u32) -> Choice {
+    pub fn is_outside_bound(&self, bound: u32) -> Choice {
         debug_assert!(self.0 < DILITHIUM_Q);
         debug_assert!(bound < u32::MAX / 2); // required for panic-free 2*bound-1 range window.
 
@@ -175,7 +175,7 @@ impl FieldElement<Standard> {
 
     /// FIPS-204, Algorithm 36.
     /// Returns (r1, r0) with r = r1*2γ2 + r0 (mod q)
-    pub(crate) fn decompose<P: MlDsaParameters>(&self) -> (u32, u32) {
+    pub fn decompose<P: MlDsaParameters>(&self) -> (u32, u32) {
         debug_assert!(self.0 < DILITHIUM_Q);
         // 2γ2
         let two_gamma2 = 2 * P::GAMMA_2;
@@ -199,12 +199,12 @@ impl FieldElement<Standard> {
     }
 
     /// FIPS-204, Algorithm 37.
-    pub(crate) fn high_bits<P: MlDsaParameters>(&self) -> u32 {
+    pub fn high_bits<P: MlDsaParameters>(&self) -> u32 {
         self.decompose::<P>().0
     }
 
     /// FIPS-204, Algorithm 39.
-    pub(crate) fn make_hint<P: MlDsaParameters>(&self, z: &Self) -> Choice {
+    pub fn make_hint<P: MlDsaParameters>(&self, z: &Self) -> Choice {
         let hibits_clean = self.high_bits::<P>();
         let hibits_add = (*self + z).high_bits::<P>();
 
@@ -212,7 +212,7 @@ impl FieldElement<Standard> {
     }
 
     /// FIPS-204, Algorithm 40.
-    pub(crate) fn use_hint<P: MlDsaParameters>(&self, hint: u32) -> u32 {
+    pub fn use_hint<P: MlDsaParameters>(&self, hint: u32) -> u32 {
         debug_assert!(hint == 0 || hint == 1); // hint is bit
 
         let (r1, r0) = self.decompose::<P>();
@@ -232,7 +232,7 @@ impl FieldElement<Standard> {
         (adjust & hint) | (r1 & !hint)
     }
 
-    pub(crate) fn bitpack_gamma1_offset<P: MlDsaParameters>(&self) -> u32 {
+    pub fn bitpack_gamma1_offset<P: MlDsaParameters>(&self) -> u32 {
         debug_assert!(self.0 < DILITHIUM_Q);
         let t = conditional_sub_u32(P::GAMMA_1 + DILITHIUM_Q - self.0);
         debug_assert!(t < 2 * P::GAMMA_1); // ||z||infinity norm bound on gamma1
@@ -242,7 +242,7 @@ impl FieldElement<Standard> {
 }
 
 impl<D: Domain> FieldElement<D> {
-    pub(crate) const fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self(0, PhantomData)
     }
 

--- a/src/hazardous/dsa/ml_dsa/internal/fe.rs
+++ b/src/hazardous/dsa/ml_dsa/internal/fe.rs
@@ -59,7 +59,7 @@ pub(crate) const fn conditional_sub_u32(a: u32) -> u32 {
     (t & !mask) | (a & mask)
 }
 
-const fn montgomery_reduce(value: u64) -> u32 {
+pub const fn montgomery_reduce(value: u64) -> u32 {
     // cast to u32 and wrapping_mul to use lower 32 bits
     let t: u32 = (value as u32).wrapping_mul(QNEGINV);
     let r: u32 = (value

--- a/src/hazardous/dsa/ml_dsa/internal/fe.rs
+++ b/src/hazardous/dsa/ml_dsa/internal/fe.rs
@@ -59,6 +59,7 @@ pub(crate) const fn conditional_sub_u32(a: u32) -> u32 {
     (t & !mask) | (a & mask)
 }
 
+/// Montgomery reduce.
 pub const fn montgomery_reduce(value: u64) -> u32 {
     // cast to u32 and wrapping_mul to use lower 32 bits
     let t: u32 = (value as u32).wrapping_mul(QNEGINV);
@@ -74,6 +75,7 @@ mod sealed {
     pub trait Sealed {}
 }
 
+/// Domain markers to/from Montgomery.
 pub trait Domain: sealed::Sealed + Copy + Debug + PartialEq + Eq {}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -145,11 +147,13 @@ impl<D: Domain> Zeroize for FieldElement<D> {
 
 /// Specific routines for non-Montgomery domain field elements.
 impl FieldElement<Standard> {
+    #[allow(missing_docs)]
     pub const fn new(n: u32) -> Self {
         debug_assert!(n < DILITHIUM_Q);
         Self(n, PhantomData)
     }
 
+    #[allow(missing_docs)]
     pub const fn power2round<P: MlDsaParameters>(&self) -> (u32, u32) {
         debug_assert!(self.0 < DILITHIUM_Q);
         let r1 = (self.0.overflowing_add((1 << (P::D - 1)) - 1).0) >> P::D;
@@ -158,6 +162,7 @@ impl FieldElement<Standard> {
         (r1, conditional_sub_u32(r0))
     }
 
+    #[allow(missing_docs)]
     pub fn is_outside_bound(&self, bound: u32) -> Choice {
         debug_assert!(self.0 < DILITHIUM_Q);
         debug_assert!(bound < u32::MAX / 2); // required for panic-free 2*bound-1 range window.
@@ -232,6 +237,7 @@ impl FieldElement<Standard> {
         (adjust & hint) | (r1 & !hint)
     }
 
+    #[allow(missing_docs)]
     pub fn bitpack_gamma1_offset<P: MlDsaParameters>(&self) -> u32 {
         debug_assert!(self.0 < DILITHIUM_Q);
         let t = conditional_sub_u32(P::GAMMA_1 + DILITHIUM_Q - self.0);
@@ -242,6 +248,7 @@ impl FieldElement<Standard> {
 }
 
 impl<D: Domain> FieldElement<D> {
+    #[allow(missing_docs)]
     pub const fn zero() -> Self {
         Self(0, PhantomData)
     }

--- a/src/hazardous/dsa/ml_dsa/internal/mod.rs
+++ b/src/hazardous/dsa/ml_dsa/internal/mod.rs
@@ -37,7 +37,7 @@ use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
-mod fe;
+pub mod fe;
 pub(crate) mod sampling;
 
 pub(crate) const fn bitlen(a: u32) -> u32 {

--- a/src/hazardous/dsa/mod.rs
+++ b/src/hazardous/dsa/mod.rs
@@ -26,3 +26,6 @@ pub(crate) mod ml_dsa;
 pub use ml_dsa::mldsa44;
 pub use ml_dsa::mldsa65;
 pub use ml_dsa::mldsa87;
+
+#[cfg(feature = "ct-test")]
+pub use ml_dsa::internal::fe::{Domain, FieldElement, montgomery_reduce};

--- a/src/hazardous/dsa/mod.rs
+++ b/src/hazardous/dsa/mod.rs
@@ -29,4 +29,7 @@ pub use ml_dsa::mldsa87;
 
 #[doc(hidden)]
 #[cfg(feature = "ct-test")]
-pub use ml_dsa::internal::{MlDsaParameters, MlDsa44, MlDsa65, MlDsa87, fe::{Domain, FieldElement, montgomery_reduce}};
+pub use ml_dsa::internal::{
+    MlDsa44, MlDsa65, MlDsa87, MlDsaParameters,
+    fe::{Domain, FieldElement, Standard, montgomery_reduce},
+};

--- a/src/hazardous/dsa/mod.rs
+++ b/src/hazardous/dsa/mod.rs
@@ -27,5 +27,6 @@ pub use ml_dsa::mldsa44;
 pub use ml_dsa::mldsa65;
 pub use ml_dsa::mldsa87;
 
+#[doc(hidden)]
 #[cfg(feature = "ct-test")]
-pub use ml_dsa::internal::fe::{Domain, FieldElement, montgomery_reduce};
+pub use ml_dsa::internal::{MlDsaParameters, MlDsa44, MlDsa65, MlDsa87, fe::{Domain, FieldElement, montgomery_reduce}};

--- a/src/hazardous/kem/ml_kem/internal/fe.rs
+++ b/src/hazardous/kem/ml_kem/internal/fe.rs
@@ -50,8 +50,8 @@ pub fn barrett_reduce(value: u32) -> u32 {
     ret
 }
 
-// Constant-time conditional subtraction
-fn conditional_sub_u32(a: u32) -> u32 {
+/// Constant-time conditional subtraction
+pub fn conditional_sub_u32(a: u32) -> u32 {
     // Calculate a - mod
     let t: u32 = a.overflowing_sub(KYBER_Q).0;
 
@@ -75,12 +75,14 @@ impl Zeroize for FieldElement {
 }
 
 impl FieldElement {
+    /// Create new field element.
     pub fn new(value: u32) -> Self {
         debug_assert!((0..KYBER_Q).contains(&value));
 
         Self(value)
     }
 
+    /// New zero field element.
     pub fn zero() -> Self {
         Self(0)
     }
@@ -126,6 +128,7 @@ impl FieldElement {
     }
 
     #[cfg(all(test, feature = "safe_api"))]
+    #[allow(missing_docs)]
     pub fn random() -> Self {
         use rand::prelude::*;
         Self(rand::rng().random_range(0..KYBER_Q))

--- a/src/hazardous/kem/ml_kem/internal/mod.rs
+++ b/src/hazardous/kem/ml_kem/internal/mod.rs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 /// Field elements in Z_m where m = q.
-pub(crate) mod fe;
+pub mod fe;
 
 /// Ring elements in R_q and T_q (NTT representative).
 pub(crate) mod re;

--- a/src/hazardous/kem/mod.rs
+++ b/src/hazardous/kem/mod.rs
@@ -32,3 +32,7 @@ pub use ml_kem::mlkem1024;
 
 /// X-Wing hybrid KEM as specified in [draft-connolly-cfrg-xwing-kem-10](https://www.ietf.org/archive/id/draft-connolly-cfrg-xwing-kem-10.html).
 pub mod xwing;
+
+#[doc(hidden)]
+#[cfg(feature = "ct-test")]
+pub use ml_kem::internal::fe::{FieldElement, barrett_reduce, conditional_sub_u32};


### PR DESCRIPTION
With ML-DSA also supported the amount of copy-paste from here to orion-dudect would've been immense. Selectively make internal functions public that need testing.